### PR TITLE
fix: Podspec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,4 @@ jobs:
       - name: Install Podfiles
         run: cd example && npx pod-install
       - name: Build example app
-        run: yarn ios
+        run: cd example && yarn ios

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -429,7 +429,7 @@ SPEC CHECKSUMS:
   React-jsi: b6dc94a6a12ff98e8877287a0b7620d365201161
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
-  react-native-menu: 43365822d4fa708c5e55fad56a3d2269acf6e3a8
+  react-native-menu: 5fc4e3f8063f00792e2aa0a1f12a0cba65d0a122
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71

--- a/ios/Menu-Bridging-Header.h
+++ b/ios/Menu-Bridging-Header.h
@@ -2,5 +2,4 @@
 #import <React/RCTViewManager.h>
 #import <React/RCTView.h>
 
-#import "RCTConvert+UIAction.h"
 

--- a/react-native-menu.podspec
+++ b/react-native-menu.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   
 
-  s.dependency "React-Core"
+  s.dependency "React"
 end


### PR DESCRIPTION
# Overview

Fixes podspec to use `React` instead of `React-Core`. This is required for projects using Swift until React Native 0.64
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan
pod install runs without problem
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
