### PR TITLE
feat(#57): android missing action properties, ios image color

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,23 @@ const App = () => {
         actions={[
           {
             id: 'add',
-            title: 'Add to List',
-            image: 'plus',
+            titleColor: '#2367A2',
+            image: Platform.select({
+              ios: 'plus',
+              android: 'ic_menu_add',
+            }),
+            imageColor: '#2367A2',
           },
           {
             id: 'share',
             title: 'Share Action',
+            titleColor: '#46F289',
             subtitle: 'Share action on SNS',
-            image: 'square.and.arrow.up',
+            image: Platform.select({
+              ios: 'square.and.arrow.up',
+              android: 'ic_menu_share',
+            }),
+            imageColor: '#46F289',
             state: 'on',
           },
           {
@@ -71,7 +80,10 @@ const App = () => {
             attributes: {
               destructive: true,
             },
-            image: 'trash',
+            image: Platform.select({
+              ios: 'trash',
+              android: 'ic_menu_delete',
+            }),
           },
         ]}
       >
@@ -120,27 +132,44 @@ export type MenuAction = {
    */
   title: string;
   /**
+   * (Android only)
+   * The action's title color.
+   * @platform Android
+   */
+  titleColor?: number | ColorValue;
+  /**
    * (iOS14+ only)
    * An elaborated title that explains the purpose of the action.
+   * @platform iOS
    */
   subtitle?: string;
   /**
-   * (iOS only)
    * The attributes indicating the style of the action.
    */
   attributes?: MenuAttributes;
   /**
    * (iOS14+ only)
    * The state of the action.
+   * @platform iOS
    */
   state?: MenuState;
   /**
-   * (iOS13+ only)
+   * (Android and iOS13+ only)
    * - The action's image.
-   * - Allows icon name included in SF Symbol
-   * - TODO: Allow images other than those included in SF Symbol
+   * - Allows icon name included in project or system (Android) resources drawables and
+   * in SF Symbol (iOS)
+   * @example // (iOS)
+   * image="plus"
+   * @example // (Android)
+   * image="ic_menu_add"
+   * - TODO: Allow images other than those included in SF Symbol and resources drawables
    */
   image?: string;
+  /**
+   * (Android and iOS13+ only)
+   * - The action's image color.
+   */
+  imageColor?: number | ColorValue;
 };
 ```
 
@@ -152,17 +181,14 @@ The attributes indicating the style of the action.
 type MenuAttributes = {
   /**
    * An attribute indicating the destructive style.
-   * @platform iOS
    */
   destructive?: boolean;
   /**
    * An attribute indicating the disabled style.
-   * @platform iOS
    */
   disabled?: boolean;
   /**
    * An attribute indicating the hidden style.
-   * @platform iOS
    */
   hidden?: boolean;
 };

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,13 +29,13 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"
-    
+
   }
-  
+
   buildTypes {
     release {
       minifyEnabled false

--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -1,5 +1,12 @@
 package com.reactnativemenu
 
+import android.content.res.ColorStateList
+import android.content.res.Resources
+import android.graphics.Color
+import android.os.Build
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.style.ForegroundColorSpan
 import android.view.Menu
 import android.view.MotionEvent
 import android.widget.PopupMenu
@@ -9,6 +16,8 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.facebook.react.views.view.ReactViewGroup
+import java.lang.reflect.Field
+
 
 class MenuView(context: ReactContext): ReactViewGroup(context) {
   private lateinit var mActions: ReadableArray
@@ -41,11 +50,85 @@ class MenuView(context: ReactContext): ReactViewGroup(context) {
 
   private fun prepareMenu() {
     if (getActionsCount > 0) {
-      var i = 0
       mPopupMenu.menu.clear()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        mPopupMenu.setForceShowIcon(true)
+      }
+      var i = 0
       while (i < getActionsCount) {
         val item = mActions.getMap(i)
-        mPopupMenu.menu.add(Menu.NONE, Menu.NONE, i, item.getString("title"))
+        val menuItem = mPopupMenu.menu.add(Menu.NONE, Menu.NONE, i, item.getString("title"))
+
+        val titleColor = when (item.hasKey("titleColor")) {
+          true -> item.getInt("titleColor")
+          false -> null
+        }
+        val imageName = when (item.hasKey("image")) {
+          true -> item.getString("image")
+          false -> null
+        }
+        val imageColor = when (item.hasKey("imageColor")) {
+          true -> item.getInt("imageColor")
+          false -> null
+        }
+        val attributes = when (item.hasKey("attributes")) {
+          true -> item.getMap("attributes")
+          false -> null
+        }
+
+        if (titleColor != null) {
+          menuItem.title = getMenuItemTextWithColor(menuItem.title.toString(), titleColor)
+        }
+
+        if (imageName != null) {
+          val resourceId: Int = getDrawableIdWithName(imageName)
+          if (resourceId != 0) {
+            val icon = resources.getDrawable(resourceId, context.theme)
+            if (imageColor != null) {
+              icon.setTintList(ColorStateList.valueOf(imageColor))
+            }
+            menuItem.icon = icon
+          }
+        }
+
+        if (attributes != null) {
+          // actions.attributes.disabled
+          val disabled = when (attributes.hasKey("disabled")) {
+            true -> attributes.getBoolean("disabled")
+            false -> false
+          }
+          menuItem.isEnabled = !disabled
+          if (!menuItem.isEnabled) {
+            val disabledColor = 0x77888888
+            menuItem.title = getMenuItemTextWithColor(menuItem.title.toString(), disabledColor)
+            if (imageName != null) {
+              val icon = menuItem.icon
+              icon.setTintList(ColorStateList.valueOf(disabledColor))
+              menuItem.icon = icon
+            }
+          }
+
+          // actions.attributes.hidden
+          val hidden = when (attributes.hasKey("hidden")) {
+            true -> attributes.getBoolean("hidden")
+            false -> false
+          }
+          menuItem.isVisible = !hidden
+
+          // actions.attributes.destructive
+          val destructive = when (attributes.hasKey("destructive")) {
+            true -> attributes.getBoolean("destructive")
+            false -> false
+          }
+          if (destructive) {
+            menuItem.title = getMenuItemTextWithColor(menuItem.title.toString(), Color.RED)
+            if (imageName != null) {
+              val icon = menuItem.icon
+              icon.setTintList(ColorStateList.valueOf(Color.RED))
+              menuItem.icon = icon
+            }
+          }
+        }
         i++
       }
       mPopupMenu.setOnMenuItemClickListener { it ->
@@ -65,5 +148,33 @@ class MenuView(context: ReactContext): ReactViewGroup(context) {
       mIsMenuDisplayed = true
       mPopupMenu.show()
     }
+  }
+
+  private fun getDrawableIdWithName(name: String): Int {
+    val appResources: Resources = context.resources
+    var resourceId = appResources.getIdentifier(name, "drawable", context.packageName)
+    if (resourceId == 0) {
+      // If drawable is not present in app's resources, check system's resources
+      resourceId = getResId(name, android.R.drawable::class.java)
+    }
+    return resourceId
+  }
+
+  private fun getResId(resName: String?, c: Class<*>): Int {
+    return try {
+      val idField: Field = c.getDeclaredField(resName!!)
+      idField.getInt(idField)
+    } catch (e: Exception) {
+      e.printStackTrace()
+      0
+    }
+  }
+
+  private fun getMenuItemTextWithColor(text: String, color: Int): SpannableStringBuilder {
+    val textWithColor = SpannableStringBuilder()
+    textWithColor.append(text)
+    textWithColor.setSpan(ForegroundColorSpan(color),
+      0, text.length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+    return textWithColor
   }
 }

--- a/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
@@ -137,7 +137,7 @@ class MenuViewManager: ReactClippingViewManager<MenuView>() {
     if (!YogaConstants.isUndefined(width)) {
       width = PixelUtil.toPixelFromDIP(width)
     }
-    view.setBorderWidth(SPACING_TYPES.get(index), width)
+    view.setBorderWidth(SPACING_TYPES[index], width)
   }
 
   @ReactPropGroup(names = [ViewProps.BORDER_COLOR, ViewProps.BORDER_LEFT_COLOR, ViewProps.BORDER_RIGHT_COLOR, ViewProps.BORDER_TOP_COLOR, ViewProps.BORDER_BOTTOM_COLOR, ViewProps.BORDER_START_COLOR, ViewProps.BORDER_END_COLOR], customType = "Color")

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { Platform, StyleSheet, Text, View } from 'react-native';
 import { MenuView } from '@react-native-menu/menu';
 
 export const App = () => {
@@ -14,20 +14,35 @@ export const App = () => {
           {
             id: 'add',
             title: 'Add to List',
-            image: 'plus',
+            titleColor: '#2367A2',
+            image: Platform.select({
+              ios: 'plus',
+              android: 'ic_menu_add',
+            }),
+            imageColor: '#2367A2',
           },
           {
             id: 'share',
             title: 'Share Action',
+            titleColor: '#46F289',
             subtitle: 'Share action on SNS',
-            image: 'square.and.arrow.up',
+            image: Platform.select({
+              ios: 'square.and.arrow.up',
+              android: 'ic_menu_share',
+            }),
+            imageColor: '#46F289',
             state: 'on',
           },
           {
             id: 'mixed',
             title: 'Mixed State',
+            titleColor: 'rgba(100,200,250,0.3)',
             subtitle: 'State is mixed',
-            image: 'heart.fill',
+            image: Platform.select({
+              ios: 'heart.fill',
+              android: 'ic_menu_today',
+            }),
+            imageColor: 'rgba(100,200,250,0.3)',
             state: 'mixed',
           },
           {
@@ -37,7 +52,10 @@ export const App = () => {
             attributes: {
               disabled: true,
             },
-            image: 'tray',
+            image: Platform.select({
+              ios: 'tray',
+              android: 'ic_menu_agenda',
+            }),
           },
           {
             id: 'hidden',
@@ -53,7 +71,10 @@ export const App = () => {
             attributes: {
               destructive: true,
             },
-            image: 'trash',
+            image: Platform.select({
+              ios: 'trash',
+              android: 'ic_menu_delete',
+            }),
           },
         ]}
       >

--- a/ios/RCTAlertAction.swift
+++ b/ios/RCTAlertAction.swift
@@ -31,6 +31,9 @@ class RCTAlertAction {
         if let image = details["image"] as? NSString {
             if #available(iOS 13.0, *) {
                 self.image = UIImage(systemName: image as String)
+                if let imageColor = details["imageColor"] {
+                    self.image = self.image?.withTintColor(RCTConvert.uiColor(imageColor), renderingMode: .alwaysOriginal)
+                }
             } else {
                 self.image = UIImage(named: image as String)
             };
@@ -54,7 +57,7 @@ class RCTAlertAction {
         if self.isHidden {
             return nil
         }
-        let action =  UIAlertAction(title: title, style: style, handler: {_ in
+        let action = UIAlertAction(title: title, style: style, handler: {_ in
             handleEvent(self.identifier ?? self.title)
         })
         if self.image != nil {

--- a/ios/RCTMenuItem.swift
+++ b/ios/RCTMenuItem.swift
@@ -12,9 +12,9 @@ class RCTMenuAction {
     
     var identifier: UIAction.Identifier?;
     var title: String;
-    var subtitle: String?;
+    var subtitle: String?
     var image: UIImage?
-    var attributes: UIAction.Attributes = [];
+    var attributes: UIAction.Attributes = []
     var state: UIAction.State = .off
     
     init(details: NSDictionary){
@@ -25,6 +25,9 @@ class RCTMenuAction {
         
         if let image = details["image"] as? NSString {
             self.image = UIImage(systemName: image as String);
+            if let imageColor = details["imageColor"] {
+                self.image = self.image?.withTintColor(RCTConvert.uiColor(imageColor), renderingMode: .alwaysOriginal)
+            }
         }
         
         if let title = details["title"] as? NSString {

--- a/src/UIMenuView.android.tsx
+++ b/src/UIMenuView.android.tsx
@@ -1,8 +1,8 @@
 import { HostComponent, requireNativeComponent } from 'react-native';
-import type { MenuComponentProps } from './types';
+import type { NativeMenuComponentProps } from './types';
 
 const MenuComponent = requireNativeComponent(
   'MenuView'
-) as HostComponent<MenuComponentProps>;
+) as HostComponent<NativeMenuComponentProps>;
 
 export default MenuComponent;

--- a/src/UIMenuView.ios.tsx
+++ b/src/UIMenuView.ios.tsx
@@ -1,8 +1,8 @@
 import { HostComponent, requireNativeComponent } from 'react-native';
-import type { MenuComponentProps } from './types';
+import type { NativeMenuComponentProps } from './types';
 
 const MenuComponent = requireNativeComponent(
   'RCTUIMenu'
-) as HostComponent<MenuComponentProps>;
+) as HostComponent<NativeMenuComponentProps>;
 
 export default MenuComponent;

--- a/src/UIMenuView.tsx
+++ b/src/UIMenuView.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { View } from 'react-native';
-import type { MenuComponentProps } from './types';
+import type { NativeMenuComponentProps } from './types';
 
 /**
- * TODO: implement for Android and Web
+ * TODO: implement for Web
  */
-const MenuView: React.FC<MenuComponentProps> = ({ style, children }) => {
+const MenuView: React.FC<NativeMenuComponentProps> = ({ style, children }) => {
   return <View style={style}>{children}</View>;
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,21 @@
-import MenuView from './UIMenuView';
-import type { MenuComponentProps, MenuAction } from './types';
+import React from 'react';
+import { processColor } from 'react-native';
+
+import UIMenuView from './UIMenuView';
+import type {
+  MenuComponentProps,
+  MenuAction,
+  ProcessedMenuAction,
+} from './types';
+
+const MenuView: React.FC<MenuComponentProps> = ({ actions, ...props }) => {
+  const processedActions = actions.map<ProcessedMenuAction>((action) => ({
+    ...action,
+    imageColor: processColor(action.imageColor),
+    titleColor: processColor(action.titleColor),
+  }));
+  return <UIMenuView {...props} actions={processedActions} />;
+};
+
 export { MenuView };
 export type { MenuComponentProps, MenuAction };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
-import type { StyleProp, ViewStyle } from 'react-native';
+import type {
+  ColorValue,
+  processColor,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 type NativeActionEvent = {
   nativeEvent: {
@@ -9,17 +14,14 @@ type NativeActionEvent = {
 type MenuAttributes = {
   /**
    * An attribute indicating the destructive style.
-   * @platform iOS
    */
   destructive?: boolean;
   /**
    * An attribute indicating the disabled style.
-   * @platform iOS
    */
   disabled?: boolean;
   /**
    * An attribute indicating the hidden style.
-   * @platform iOS
    */
   hidden?: boolean;
 };
@@ -43,8 +45,15 @@ export type MenuAction = {
    */
   title: string;
   /**
+   * (Android only)
+   * The action's title color.
+   * @platform Android
+   */
+  titleColor?: number | ColorValue;
+  /**
    * (iOS14+ only)
    * An elaborated title that explains the purpose of the action.
+   * @platform iOS
    */
   subtitle?: string;
   /**
@@ -54,15 +63,26 @@ export type MenuAction = {
   /**
    * (iOS14+ only)
    * The state of the action.
+   * @platform iOS
    */
   state?: MenuState;
   /**
-   * (iOS13+ only)
+   * (Android and iOS13+ only)
    * - The action's image.
-   * - Allows icon name included in SF Symbol
-   * - TODO: Allow images other than those included in SF Symbol
+   * - Allows icon name included in project or system (Android) resources drawables and
+   * in SF Symbol (iOS)
+   * @example // (iOS)
+   * image="plus"
+   * @example // (Android)
+   * image="ic_menu_add"
+   * - TODO: Allow images other than those included in SF Symbol and resources drawables
    */
   image?: string;
+  /**
+   * (Android and iOS13+ only)
+   * - The action's image color.
+   */
+  imageColor?: number | ColorValue;
 };
 
 export type MenuComponentProps = {
@@ -79,5 +99,20 @@ export type MenuComponentProps = {
   /**
    * The title of the menu.
    */
+  title?: string;
+};
+
+export type ProcessedMenuAction = Omit<
+  MenuAction,
+  'imageColor' | 'titleColor'
+> & {
+  imageColor: ReturnType<typeof processColor>;
+  titleColor: ReturnType<typeof processColor>;
+};
+
+export type NativeMenuComponentProps = {
+  style?: StyleProp<ViewStyle>;
+  onPressAction?: ({ nativeEvent }: NativeActionEvent) => void;
+  actions: ProcessedMenuAction[];
   title?: string;
 };


### PR DESCRIPTION
# Overview

Hi, I implemented missing android menu configuration which includes attributes matching iOS behavior, android icon (can be any android drawable from app's or system resources) and *color props for action title (Android only) and action image/icon

- android action attributes (destructive, hidden, disabled)
- android action title color
- android action image and image color
- ios image color
- readme update with new props available

Closes #57 