### PR TITLE
feat(#64): isAnchoredToRight android value

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ The title of the menu.
 | ------ | -------- |
 | string | No       |
 
+### `isAnchoredToRight` (Android only)
+
+Boolean determining if menu should anchored to right or left corner of parent view.
+
+| Type    | Required |
+| ------- | -------- |
+| boolean | No       |
+
 ### `actions`
 
 Actions to be displayed in the menu.

--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
+import android.view.Gravity
 import android.view.Menu
 import android.view.MotionEvent
 import android.widget.PopupMenu
@@ -19,9 +20,9 @@ import com.facebook.react.views.view.ReactViewGroup
 import java.lang.reflect.Field
 
 
-class MenuView(context: ReactContext): ReactViewGroup(context) {
+class MenuView(private val mContext: ReactContext): ReactViewGroup(mContext) {
   private lateinit var mActions: ReadableArray
-  private var mContext: ReactContext = context as ReactContext
+  private var mIsAnchoredToRight = false
   private val mPopupMenu: PopupMenu = PopupMenu(context, this)
   private var mIsMenuDisplayed = false
 
@@ -42,7 +43,14 @@ class MenuView(context: ReactContext): ReactViewGroup(context) {
   }
 
   fun setActions(actions: ReadableArray) {
-    this.mActions = actions
+    mActions = actions
+  }
+
+  fun setIsAnchoredToRight(isAnchoredToRight: Boolean) {
+    if (mIsAnchoredToRight == isAnchoredToRight) {
+      return
+    }
+    mIsAnchoredToRight = isAnchoredToRight
   }
 
   private val getActionsCount: Int
@@ -51,6 +59,12 @@ class MenuView(context: ReactContext): ReactViewGroup(context) {
   private fun prepareMenu() {
     if (getActionsCount > 0) {
       mPopupMenu.menu.clear()
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        mPopupMenu.gravity = when (mIsAnchoredToRight) {
+          true -> Gravity.RIGHT
+          false -> Gravity.LEFT
+        }
+      }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
         mPopupMenu.setForceShowIcon(true)
       }

--- a/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
@@ -29,6 +29,11 @@ class MenuViewManager: ReactClippingViewManager<MenuView>() {
     view.setActions(actions)
   }
 
+  @ReactProp(name = "isAnchoredToRight", defaultBoolean = false)
+  fun setIsAnchoredToRight(view: MenuView, isAnchoredToRight: Boolean) {
+    view.setIsAnchoredToRight(isAnchoredToRight)
+  }
+
   override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     return MapBuilder.of(
       "onPressAction",

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,13 @@ export type MenuComponentProps = {
    * The title of the menu.
    */
   title?: string;
+  /**
+   * (Android API 23+)
+   * Boolean value determines whether popup menu should be anchored
+   * to right corner of parent view - default value is `false`
+   * @platform Android
+   */
+  isAnchoredToRight?: boolean;
 };
 
 export type ProcessedMenuAction = Omit<


### PR DESCRIPTION
# Overview

Hi, I added prop for switching android menu anchor to parent view, whether it is anchored to right or left corner of parent view 

Closes #64 

# Test Plan

Run Android example app and pass `isAnchoredToRight` prop with value set to `true`
