### PR TITLE
feat(#80): sub menus functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ const App = () => {
               android: 'ic_menu_add',
             }),
             imageColor: '#2367A2',
+            subactions: [
+              {
+                id: 'nested1',
+                title: 'Nested action',
+                titleColor: 'rgba(250,180,100,0.5)',
+                subtitle: 'State is mixed',
+                image: Platform.select({
+                  ios: 'heart.fill',
+                  android: 'ic_menu_today',
+                }),
+                imageColor: 'rgba(100,200,250,0.3)',
+                state: 'mixed',
+              },
+              {
+                id: 'nestedDestructive',
+                title: 'Destructive Action',
+                attributes: {
+                  destructive: true,
+                },
+                image: Platform.select({
+                  ios: 'trash',
+                  android: 'ic_menu_delete',
+                }),
+              },
+            ],
           },
           {
             id: 'share',
@@ -178,6 +203,12 @@ export type MenuAction = {
    * - The action's image color.
    */
   imageColor?: number | ColorValue;
+  /**
+   * (Android and iOS14+ only)
+   * - Actions to be displayed in the sub menu
+   * - On Android it does not support nesting next sub menus in sub menu item
+   */
+  subactions?: MenuAction[];
 };
 ```
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -20,6 +20,31 @@ export const App = () => {
               android: 'ic_menu_add',
             }),
             imageColor: '#2367A2',
+            subactions: [
+              {
+                id: 'nested1',
+                title: 'Nested action',
+                titleColor: 'rgba(250,180,100,0.5)',
+                subtitle: 'State is mixed',
+                image: Platform.select({
+                  ios: 'heart.fill',
+                  android: 'ic_menu_today',
+                }),
+                imageColor: 'rgba(100,200,250,0.3)',
+                state: 'mixed',
+              },
+              {
+                id: 'nestedDestructive',
+                title: 'Destructive Action',
+                attributes: {
+                  destructive: true,
+                },
+                image: Platform.select({
+                  ios: 'trash',
+                  android: 'ic_menu_delete',
+                }),
+              },
+            ],
           },
           {
             id: 'share',
@@ -44,6 +69,63 @@ export const App = () => {
             }),
             imageColor: 'rgba(100,200,250,0.3)',
             state: 'mixed',
+            subactions: [
+              {
+                id: 'nested2',
+                title: 'Nested action',
+                titleColor: 'rgba(250,180,100,0.5)',
+                subtitle: 'State is mixed',
+                image: Platform.select({
+                  ios: 'tray',
+                  android: 'ic_menu_agenda',
+                }),
+                imageColor: 'rgba(100,200,250,0.3)',
+                state: 'mixed',
+              },
+              {
+                id: 'nestedMixed',
+                title: 'Mixed State',
+                subtitle: 'State is mixed',
+                image: Platform.select({
+                  ios: 'heart.fill',
+                  android: 'ic_menu_today',
+                }),
+                imageColor: '#46F289',
+                subactions: [
+                  {
+                    id: 'nestednesteddisabled',
+                    title: 'Disabled Action',
+                    subtitle: 'Action is disabled',
+                    attributes: {
+                      disabled: true,
+                    },
+                    image: Platform.select({
+                      ios: 'tray',
+                      android: 'ic_menu_agenda',
+                    }),
+                  },
+                  {
+                    id: 'nestednestedhidden',
+                    title: 'Hidden Action',
+                    subtitle: 'Action is hidden',
+                    attributes: {
+                      hidden: true,
+                    },
+                  },
+                  {
+                    id: 'nestednesteddestructive',
+                    title: 'Destructive Action',
+                    attributes: {
+                      destructive: true,
+                    },
+                    image: Platform.select({
+                      ios: 'trash',
+                      android: 'ic_menu_delete',
+                    }),
+                  },
+                ],
+              },
+            ],
           },
           {
             id: 'disabled',

--- a/ios/MenuView.swift
+++ b/ios/MenuView.swift
@@ -10,14 +10,14 @@ import UIKit
 @objc(MenuView)
 class MenuView: UIButton {
 
-    private var _actions: [UIAction] = [];
+    private var _actions: [UIMenuElement] = [];
     @objc var actions: [NSDictionary]? {
         didSet {
             guard let actions = self.actions else {
                 return
             }
             actions.forEach { menuAction in
-                _actions.append(RCTMenuAction(details: menuAction).createUIAction({action in self.sendButtonAction(action)}))
+                _actions.append(RCTMenuAction(details: menuAction).createUIMenuElement({action in self.sendButtonAction(action)}))
             }
             self.setup()
         }

--- a/ios/RCTMenuItem.swift
+++ b/ios/RCTMenuItem.swift
@@ -16,6 +16,7 @@ class RCTMenuAction {
     var image: UIImage?
     var attributes: UIAction.Attributes = []
     var state: UIAction.State = .off
+    var subactions: [RCTMenuAction] = []
     
     init(details: NSDictionary){
         
@@ -64,10 +65,25 @@ class RCTMenuAction {
             }
         }
         
+        if let subactions = details["subactions"] as? NSArray {
+            if subactions.count > 0 {
+                for subaction in subactions {
+                    self.subactions.append(RCTMenuAction(details: subaction as! NSDictionary))
+                }
+            }
+        }
+        
         
     }
     
-    func createUIAction(_ handler: @escaping UIActionHandler) -> UIAction {
+    func createUIMenuElement(_ handler: @escaping UIActionHandler) -> UIMenuElement {
+        if subactions.count > 0 {
+            var subMenuActions: [UIMenuElement] = []
+            subactions.forEach { subaction in
+                subMenuActions.append(subaction.createUIMenuElement(handler))
+            }
+            return UIMenu(title: title, image: image, identifier: nil, children: subMenuActions)
+        }
         return UIAction(title: title, image: image, identifier: identifier, discoverabilityTitle: subtitle, attributes: attributes, state: state, handler: handler)
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,12 +8,19 @@ import type {
   ProcessedMenuAction,
 } from './types';
 
-const MenuView: React.FC<MenuComponentProps> = ({ actions, ...props }) => {
-  const processedActions = actions.map<ProcessedMenuAction>((action) => ({
+function processAction(action: MenuAction): ProcessedMenuAction {
+  return {
     ...action,
     imageColor: processColor(action.imageColor),
     titleColor: processColor(action.titleColor),
-  }));
+    subactions: action.subactions?.map((subAction) => processAction(subAction)),
+  };
+}
+
+const MenuView: React.FC<MenuComponentProps> = ({ actions, ...props }) => {
+  const processedActions = actions.map<ProcessedMenuAction>((action) =>
+    processAction(action)
+  );
   return <UIMenuView {...props} actions={processedActions} />;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,6 +83,12 @@ export type MenuAction = {
    * - The action's image color.
    */
   imageColor?: number | ColorValue;
+  /**
+   * (Android and iOS14+ only)
+   * - Actions to be displayed in the sub menu
+   * - On Android it does not support nesting next sub menus in sub menu item
+   */
+  subactions?: MenuAction[];
 };
 
 export type MenuComponentProps = {
@@ -111,10 +117,11 @@ export type MenuComponentProps = {
 
 export type ProcessedMenuAction = Omit<
   MenuAction,
-  'imageColor' | 'titleColor'
+  'imageColor' | 'titleColor' | 'subactions'
 > & {
   imageColor: ReturnType<typeof processColor>;
   titleColor: ReturnType<typeof processColor>;
+  subactions?: ProcessedMenuAction[];
 };
 
 export type NativeMenuComponentProps = {


### PR DESCRIPTION
# Overview

Hi, I added sub menus for Android `PopupMenu` and iOS `UIMenu`. On Android there can be 1 lvl of nested subactions, on iOS there is no limitation.

Closes #80 

# Test Plan

Run example app. On Android root items with submenu will have a icon indicating that there are some subitems to show. On iOS items that contain sub menu are displayed the same as normal items