### PR TITLE
fix(#105): Add ActionSheet support for iPad on OS versions less than 14

### DIFF
--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -54,6 +54,12 @@ class ActionSheetView: UIView {
         
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
         
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            alert.modalPresentationStyle = .popover
+            alert.popoverPresentationController?.sourceView = self
+            alert.popoverPresentationController?.sourceRect = self.bounds
+        }
+        
         if let root = RCTPresentedViewController() {
             root.present(alert, animated: true, completion: nil)
         }


### PR DESCRIPTION
# Overview

Currently, this library does not work on iPads running iOS 13 or lower. The `ActionSheet` presentation mode needs additional popover information to be presented on an iPad. This fix provides this support. 

# Test Plan

Run the example application on an iPad simulator running iOS 13 or lower
