### PR TITLE
Clear menu actions when actions are set

### DIFF
--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -27,6 +27,7 @@ class ActionSheetView: UIView {
             guard let actions = self.actions else {
                 return
             }
+            _actions.removeAll()
             actions.forEach({ alertAction in
                 if let action = RCTAlertAction(details: alertAction).createAction({
                 event in self.sendButtonAction(event)

--- a/ios/MenuView.swift
+++ b/ios/MenuView.swift
@@ -16,6 +16,7 @@ class MenuView: UIButton {
             guard let actions = self.actions else {
                 return
             }
+            _actions.removeAll()
             actions.forEach { menuAction in
                 _actions.append(RCTMenuAction(details: menuAction).createUIMenuElement({action in self.sendButtonAction(action)}))
             }


### PR DESCRIPTION
Fixes: #139 

# Overview

If I mount the Menu component with a set of actions (e.g. A, B, C) and then an event changes the set of actions to a subset (B, C) the action A is never removed because actions are only appended

# Test Plan

To test, set up a component that starts with a list of actions and then removes some of those actions from the prop list

