### PR TITLE
fix(iOS): action sheet actions only fired first time

### DIFF
--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -53,7 +53,7 @@ class ActionSheetView: UIView {
         let alert = UIAlertController(title: _title, message: nil, preferredStyle: .actionSheet)
         
         self._actions.forEach({action in
-            alert.addAction(action)
+            alert.addAction(action.copy() as! UIAlertAction)
         })
         
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
On iOS versions <= 13, the `ActionSheetView` that is used instead of the `UIMenu` has an issue where actions only fire the first time. This provides a fix for that.

Fixes #236 

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
I had no idea how to run the project standalone.. seems like either some linking went wrong or the structure is incorrect.

I tested it by modifying the pod directly in the Development Pods folder, testing on device and then applying those changes to the files directly. ~~It would be great if you could document how to actually build the project for future contributors.~~  -> nvm I'm dumb and missed the Contributing.md file...

Hope this can be accepted into the source so I won't have to patch the package myself anymore :)