### PR TITLE
fix(iOS): action sheet empty title when property not defined

### DIFF
--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -11,14 +11,9 @@ import UIKit
 @objc(ActionSheetView)
 class ActionSheetView: UIView {
     @objc var onPressAction: RCTDirectEventBlock?
-    private var _title: String = "";
+    private var _title: String?;
     @objc var title: NSString? {
-        didSet {
-            guard let title = self.title else {
-                return
-            }
-            self._title = title as String
-        }
+        didSet { self._title = title as? String }
     }
     
     private var _actions: [UIAlertAction] = [];


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
On iOS versions, the `ActionSheetView` that is used instead of the `UIMenu` has an issue.

If you don't set the title prop, without this fix, a title will be displayed blank. So the effective title is there, instead of being invisible. The UIAlertSheet's title parameter is optional, so there's no need to force fallback to `""`.

Before:
![image](https://user-images.githubusercontent.com/7591717/143585015-687107f5-884e-41ce-99c1-0540cd95ddce.png)

After:
![image](https://user-images.githubusercontent.com/7591717/143585163-3f25b2dc-5ad1-4d2c-9403-c0c7ee155c8e.png)


# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
I had no idea how to run the project standalone.. seems like either some linking went wrong or the structure is incorrect.

I tested it by modifying the pod directly in the Development Pods folder, testing on device and then applying those changes to the files directly. ~~It would be great if you could document how to actually build the project for future contributors.~~  -> nvm I'm dumb and missed the Contributing.md file...


Hope this can be accepted into the source so I won't have to patch the package myself anymore :)