### PR TITLE
feat: Export `NativeActionEvent` type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import type {
   MenuComponentProps,
   MenuAction,
   ProcessedMenuAction,
+  NativeActionEvent,
 } from './types';
 
 function processAction(action: MenuAction): ProcessedMenuAction {
@@ -25,4 +26,4 @@ const MenuView: React.FC<MenuComponentProps> = ({ actions, ...props }) => {
 };
 
 export { MenuView };
-export type { MenuComponentProps, MenuAction };
+export type { MenuComponentProps, MenuAction, NativeActionEvent };

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ import type {
   ViewStyle,
 } from 'react-native';
 
-type NativeActionEvent = {
+export type NativeActionEvent = {
   nativeEvent: {
     event: string;
   };


### PR DESCRIPTION
# Overview

Export the `NativeActionEvent` type, so users can type their `onPressAction` function.

# Test Plan

`NativeActionEvent` can successfully be imported from `'@react-native-menu/menu'`.
