### PR TITLE
fix(types): add children prop to MenuView typings

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -91,7 +91,7 @@ export type MenuAction = {
   subactions?: MenuAction[];
 };
 
-export type MenuComponentProps = {
+export interface MenuComponentProps extends PropsWithChildren {
   style?: StyleProp<ViewStyle>;
   /**
    * Callback function that will be called when selecting a menu item.


### PR DESCRIPTION
# Overview

React 18 removed the `children` prop from the `React.FC` type. This PR merges the `MenuComponentProps` with `PropsWithChildren` (to restore the behavior as of React 17)