### PR TITLE
Update Kotlin version

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-Menu_kotlinVersion=1.3.50
-Menu_compileSdkVersion=29
+Menu_kotlinVersion=1.6.10
+Menu_compileSdkVersion=30
 Menu_buildToolsVersion=30.0.3
-Menu_targetSdkVersion=29
+Menu_targetSdkVersion=30


### PR DESCRIPTION
# Overview
Fixes #394 

Updated default kotlin version so build would pass in React Native 0.69+ without modifying settings on client side

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

# Test Plan
Android build passes

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
