### PR TITLE
feat: add displayInline for submenus in iOS

### DIFF
--- a/ios/MenuView.swift
+++ b/ios/MenuView.swift
@@ -23,7 +23,7 @@ class MenuView: UIButton {
             self.setup()
         }
     }
-        
+
     private var _title: String = "";
     @objc var title: NSString? {
         didSet {
@@ -35,35 +35,35 @@ class MenuView: UIButton {
         }
     }
     @objc var onPressAction: RCTDirectEventBlock?
-    
+
     @objc var shouldOpenOnLongPress: Bool = false {
         didSet {
             self.setup()
         }
     }
-    
+
     override init(frame: CGRect) {
       super.init(frame: frame)
       self.setup()
     }
 
-    
+
     func setup () {
-        let menu = UIMenu(title:_title, identifier: nil, options: .displayInline, children: self._actions)
+        let menu = UIMenu(title:_title, identifier: nil, children: self._actions)
 
         self.menu = menu
         self.showsMenuAsPrimaryAction = !shouldOpenOnLongPress
     }
-    
+
     override func reactSetFrame(_ frame: CGRect) {
       super.reactSetFrame(frame);
     };
-    
-    
+
+
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-        
+
     @objc func sendButtonAction(_ action: UIAction) {
         if let onPress = onPressAction {
             onPress(["event":action.identifier.rawValue])

--- a/ios/RCTMenuItem.swift
+++ b/ios/RCTMenuItem.swift
@@ -9,38 +9,45 @@ import UIKit;
 
 @available(iOS 13.0, *)
 class RCTMenuAction {
-    
+
     var identifier: UIAction.Identifier?;
     var title: String;
     var subtitle: String?
+    var displayInline: Bool
     var image: UIImage?
     var attributes: UIAction.Attributes = []
     var state: UIAction.State = .off
     var subactions: [RCTMenuAction] = []
-    
+
     init(details: NSDictionary){
-        
+
         if let identifier = details["id"] as? NSString {
             self.identifier = UIAction.Identifier(rawValue: identifier as String);
         }
-        
+
         if let image = details["image"] as? NSString {
             self.image = UIImage(systemName: image as String);
             if let imageColor = details["imageColor"] {
                 self.image = self.image?.withTintColor(RCTConvert.uiColor(imageColor), renderingMode: .alwaysOriginal)
             }
         }
-        
+
         if let title = details["title"] as? NSString {
             self.title = title as String;
         } else {
             self.title = "";
         }
-        
+
         if let subtitle = details["subtitle"] as? NSString {
             self.subtitle = subtitle as String;
         }
-        
+
+        if let displayInline = details["displayInline"] as? Bool {
+            self.displayInline = displayInline as Bool;
+        } else {
+            self.displayInline = false;
+        }
+
         if let attributes = details["attributes"] as? NSDictionary {
             if (attributes["destructive"] as? Bool) == true {
                 self.attributes.update(with: .destructive)
@@ -52,7 +59,7 @@ class RCTMenuAction {
                 self.attributes.update(with: .hidden)
             }
         }
-        
+
         if let state = details["state"] as? NSString {
             if state=="on" {
                 self.state = .on
@@ -64,7 +71,7 @@ class RCTMenuAction {
                 self.state = .mixed
             }
         }
-        
+
         if let subactions = details["subactions"] as? NSArray {
             if subactions.count > 0 {
                 for subaction in subactions {
@@ -72,17 +79,21 @@ class RCTMenuAction {
                 }
             }
         }
-        
-        
+
+
     }
-    
+
     func createUIMenuElement(_ handler: @escaping UIActionHandler) -> UIMenuElement {
         if subactions.count > 0 {
             var subMenuActions: [UIMenuElement] = []
             subactions.forEach { subaction in
                 subMenuActions.append(subaction.createUIMenuElement(handler))
             }
-            return UIMenu(title: title, image: image, identifier: nil, children: subMenuActions)
+            if self.displayInline {
+                return UIMenu(title: title, image: image, options: .displayInline, children: subMenuActions)
+            } else {
+                return UIMenu(title: title, image: image, children: subMenuActions)
+            }
         }
         return UIAction(title: title, image: image, identifier: identifier, discoverabilityTitle: subtitle, attributes: attributes, state: state, handler: handler)
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,10 @@ export type MenuAction = {
    * - On Android it does not support nesting next sub menus in sub menu item
    */
   subactions?: MenuAction[];
+  /**
+   * Whether subactions should be inline (separated by divider) or nested (sub menu)
+   */
+  displayInline?: boolean;
 };
 
 type MenuComponentPropsBase = {


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

I added the option to display submenus as inline for iOS, which separates the menu items with a divider.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

This does not break any existing code, but adds the option to display existing submenus as inline for iOS. Android will continue to display as a submenu.

![Screenshot 2022-10-28 at 1 11 38 PM](https://user-images.githubusercontent.com/27737214/198724655-02f113f4-e57f-459e-9e05-6cefbebba7fa.png)
