### PR TITLE
fix: remove jcenter() in favor of mavenCentral()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 
   dependencies {
@@ -52,7 +52,6 @@ android {
 
 repositories {
   mavenCentral()
-  jcenter()
   google()
 
   def found = false


### PR DESCRIPTION
# Overview

Jfrog has sunset JCenter for a while now. Today it was offline for most of the day causing many build failures. This should fix any further issues.

# Test Plan

Did a clean test build.
