### PR TITLE
fix: upgrade gradle version

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip


### PR DESCRIPTION
# Overview 
hey maintainers, thanks for the great project.  

![image](https://user-images.githubusercontent.com/37520667/201541728-5bd20ce7-1471-4b81-bf29-1e02f8dc902a.png)



I noticed that the Gradle version is too old if the project hasn't reset default properties will cause a build error on Android. 

related: https://github.com/nandorojo/zeego/pull/27  

# How 
 I saw that project's [default kotlin version](https://github.com/react-native-menu/menu/blob/4abccac4e8aebb8f90115a0727fcff034f762719/android/gradle.properties#L1) is `1.6.10`, so I think need to upgrade Gradle version to `7.4` is correct. 


# Test Plan

check if the project build works on Android. 
