### PR TITLE
Increase responsiveness of single tap menu on Android

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -32,7 +32,7 @@ class MenuView(private val mContext: ReactContext): ReactViewGroup(mContext) {
         prepareMenu()
       }
 
-      override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+      override fun onSingleTapUp(e: MotionEvent): Boolean {
         if (!mIsOnLongPress) {
           prepareMenu()
         }


### PR DESCRIPTION
# Overview

The single-tap menu is slow to respond on Android, this is because `onSingleTapConfirmed` is used which delays calling until it's sure it's a single tap and not a double tap (not something this module ever cares about). Switching to `onSingleTapUp` causes the menu to open more quickly (and doesn't mess with the long press functionality either).

# Test Plan

Have tested manually with both single and long press setups.