### PR TITLE
Support darkMode for iOS platform

### DIFF
--- a/ios/MenuView.swift
+++ b/ios/MenuView.swift
@@ -42,6 +42,12 @@ class MenuView: UIButton {
         }
     }
 
+    @objc var darkMode: Bool = false {
+        didSet {
+            self.setup()
+        }
+    }
+
     override init(frame: CGRect) {
       super.init(frame: frame)
       self.setup()
@@ -50,7 +56,11 @@ class MenuView: UIButton {
 
     func setup () {
         let menu = UIMenu(title:_title, identifier: nil, children: self._actions)
-
+        if self.darkMode {
+          self.overrideUserInterfaceStyle = .dark
+        } else {
+          self.overrideUserInterfaceStyle = .light
+        }
         self.menu = menu
         self.showsMenuAsPrimaryAction = !shouldOpenOnLongPress
     }

--- a/ios/RCTUIMenuManager.m
+++ b/ios/RCTUIMenuManager.m
@@ -19,5 +19,9 @@ RCT_EXPORT_VIEW_PROPERTY(onPressAction, RCTDirectEventBlock);
  * shouldOpenOnLongPress: determines whether menu should be opened after long press or normal press
  */
 RCT_EXPORT_VIEW_PROPERTY(shouldOpenOnLongPress, BOOL)
+/**
+ * darkMode: determines whether menu should be dark mode or light mode
+ */
+RCT_EXPORT_VIEW_PROPERTY(darkMode, BOOL)
 
 @end

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,6 +126,7 @@ type MenuComponentPropsBase = {
   shouldOpenOnLongPress?: boolean;
   /**
    * Determines if menu should be displayed in dark mode or light mode
+   * (Only support iOS for now)
    *
    * @default false
    * @platform iOS

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,6 +124,13 @@ type MenuComponentPropsBase = {
    * @default false
    */
   shouldOpenOnLongPress?: boolean;
+  /**
+   * Determines if menu should be displayed in dark mode or light mode
+   *
+   * @default false
+   * @platform iOS
+   */
+  darkMode?: boolean;
 };
 
 export type MenuComponentProps =


### PR DESCRIPTION
# Overview

The current menu does not support dark mode for iOS and Android. I think dark mode is a good feature.
I add dark mode to iOS platform, I think it should be enabled on Android  but I am not familiar with Android.