### PR TITLE
feat(iOS): Allow menu to override system theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,14 @@ Actions to be displayed in the menu.
 | ------------ | -------- |
 | MenuAction[] | Yes      |
 
+### `themeVariant` (iOS only)
+
+String to override theme of menu
+
+| Type         | Required |
+| ------------ | -------- |
+| enum('light', 'dark') | No      |
+
 #### `MenuAction`
 
 Object representing Menu Action.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -3,6 +3,8 @@ import { Platform, StyleSheet, Text, View } from 'react-native';
 import { MenuView } from '@react-native-menu/menu';
 
 export const App = () => {
+  const [themeVariant] = React.useState<string | undefined>('light');
+
   return (
     <View style={styles.container}>
       <MenuView
@@ -160,6 +162,7 @@ export const App = () => {
           },
         ]}
         shouldOpenOnLongPress={true}
+        themeVariant={themeVariant}
       >
         <View style={styles.button}>
           <Text style={styles.buttonText}>Test</Text>

--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -34,7 +34,12 @@ class ActionSheetView: UIView {
     }
 
     @objc var shouldOpenOnLongPress: Bool = false
-    
+
+    private var _themeVariant: String?
+    @obc var themeVariant: NSString? {
+        didSet { self._themeVariant = themeVariant as? String }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         let tap = UITapGestureRecognizer(target: self, action: #selector (self.handleTap (_:)))
@@ -47,6 +52,18 @@ class ActionSheetView: UIView {
 
         let alert = UIAlertController(title: _title, message: nil, preferredStyle: .actionSheet)
         
+        if #available(iOS 13.0, *) {
+            if self._themeVariant != nil {
+                if self._themeVariant == "dark" {
+                    alert.overrideUserInterfaceStyle = .dark
+                } else if self._themeVariant == "light" {
+                    alert.overrideUserInterfaceStyle = .light
+                } else {
+                    alert.overrideUserInterfaceStyle = .unspecified
+                }
+            }
+        }
+
         self._actions.forEach({action in
             alert.addAction(action.copy() as! UIAlertAction)
         })

--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -11,12 +11,12 @@ import UIKit
 @objc(ActionSheetView)
 class ActionSheetView: UIView {
     @objc var onPressAction: RCTDirectEventBlock?
-    private var _title: String?;
+    private var _title: String?
     @objc var title: NSString? {
         didSet { self._title = title as? String }
     }
-    
-    private var _actions: [UIAlertAction] = [];
+
+    private var _actions: [UIAlertAction] = []
     @objc var actions: [NSDictionary]? {
         didSet {
             guard let actions = self.actions else {
@@ -47,7 +47,7 @@ class ActionSheetView: UIView {
         self.addGestureRecognizer(tap)
         self.addGestureRecognizer(longPress)
     }
-    
+
     func launchActionSheet() {
 
         let alert = UIAlertController(title: _title, message: nil, preferredStyle: .actionSheet)
@@ -67,22 +67,22 @@ class ActionSheetView: UIView {
         self._actions.forEach({action in
             alert.addAction(action.copy() as! UIAlertAction)
         })
-        
+
         alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
-        
+
         if UIDevice.current.userInterfaceIdiom == .pad {
             alert.modalPresentationStyle = .popover
             alert.popoverPresentationController?.sourceView = self
             alert.popoverPresentationController?.sourceRect = self.bounds
         }
-        
+
         if let root = RCTPresentedViewController() {
             root.present(alert, animated: true, completion: nil)
         }
-        
+
     }
-    
-    
+
+
     @objc func handleTap(_ sender:UITapGestureRecognizer) {
         if shouldOpenOnLongPress {
             return
@@ -93,7 +93,7 @@ class ActionSheetView: UIView {
             }
         }
     }
-    
+
     @objc func handleLongPress(_ sender: UILongPressGestureRecognizer) {
         if !shouldOpenOnLongPress {
             return
@@ -104,19 +104,19 @@ class ActionSheetView: UIView {
             }
         }
     }
-    
+
     @objc func sendButtonAction(_ action: String) {
         if let onPress = onPressAction {
             onPress(["event":action])
         }
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func reactSetFrame(_ frame: CGRect) {
-      super.reactSetFrame(frame);
-    };
-    
+      super.reactSetFrame(frame)
+    }
+
 }

--- a/ios/ActionSheetView.swift
+++ b/ios/ActionSheetView.swift
@@ -36,7 +36,7 @@ class ActionSheetView: UIView {
     @objc var shouldOpenOnLongPress: Bool = false
 
     private var _themeVariant: String?
-    @obc var themeVariant: NSString? {
+    @objc var themeVariant: NSString? {
         didSet { self._themeVariant = themeVariant as? String }
     }
 

--- a/ios/MenuView.swift
+++ b/ios/MenuView.swift
@@ -42,8 +42,10 @@ class MenuView: UIButton {
         }
     }
 
-    @objc var darkMode: Bool = false {
+    private var _themeVariant: String?
+    @objc var themeVariant: NSString? {
         didSet {
+            self._themeVariant = themeVariant as? String
             self.setup()
         }
     }
@@ -56,11 +58,17 @@ class MenuView: UIButton {
 
     func setup () {
         let menu = UIMenu(title:_title, identifier: nil, children: self._actions)
-        if self.darkMode {
-          self.overrideUserInterfaceStyle = .dark
-        } else {
-          self.overrideUserInterfaceStyle = .light
+
+        if self._themeVariant != nil {
+            if self._themeVariant == "dark" {
+                self.overrideUserInterfaceStyle = .dark
+            } else if self._themeVariant == "light" {
+                self.overrideUserInterfaceStyle = .light
+            } else {
+                self.overrideUserInterfaceStyle = .unspecified
+            }
         }
+
         self.menu = menu
         self.showsMenuAsPrimaryAction = !shouldOpenOnLongPress
     }

--- a/ios/RCTUIMenuManager.m
+++ b/ios/RCTUIMenuManager.m
@@ -20,8 +20,8 @@ RCT_EXPORT_VIEW_PROPERTY(onPressAction, RCTDirectEventBlock);
  */
 RCT_EXPORT_VIEW_PROPERTY(shouldOpenOnLongPress, BOOL)
 /**
- * darkMode: determines whether menu should be dark mode or light mode
+ * themeVariant: determines whether menu should use dark theme, light theme or system theme
  */
-RCT_EXPORT_VIEW_PROPERTY(darkMode, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(themeVariant, NSString)
 
 @end

--- a/src/types.ts
+++ b/src/types.ts
@@ -125,13 +125,12 @@ type MenuComponentPropsBase = {
    */
   shouldOpenOnLongPress?: boolean;
   /**
-   * Determines if menu should be displayed in dark mode or light mode
+   * Overrides theme variant of menu to light mode, dark mode or system theme
    * (Only support iOS for now)
    *
-   * @default false
    * @platform iOS
    */
-  darkMode?: boolean;
+  themeVariant?: string;
 };
 
 export type MenuComponentProps =


### PR DESCRIPTION
# Overview

This improves on the PR (https://github.com/react-native-menu/menu/commit/a21c18258c7c2d16b261ef800e4186032e6de995) with `themeVariant` which aims to override the current theme using the string `'dark'` and `'light'` or to respect the current system theme if `undefined` value passed.

* Previously `darkMode` will result in UIMenu to fallback to the light theme if the value is not defined, not following the system theme.

The PR also adds theming support to iOS 13 ActionSheet.

# Test Plan

The example app has been updated to include the variable `themeVariant` and changes the menu theme for iOS.

|    | iOS 16 | iOS 13 |
|--------|--------|--------|
| `'light'` | ![iOS 16 UIMenu Light Theme](https://github.com/react-native-menu/menu/assets/8110786/7027fac8-d4a4-4090-9b39-8980b2b936d2) | ![iOS 13 ActionSheet Light Theme](https://github.com/react-native-menu/menu/assets/8110786/77928e8e-558d-4c89-9ca9-d79a7d047e61) |
| `'dark'` | ![iOS 16 UIMenu Dark Theme](https://github.com/react-native-menu/menu/assets/8110786/63da0f53-9667-4715-9444-72f60104baf0) | ![iOS 13 ActionSheet Dark Theme](https://github.com/react-native-menu/menu/assets/8110786/f40ada17-0806-4216-ae7c-ed4279d5ec2c) |
| `undefined` - System Theme | https://github.com/react-native-menu/menu/assets/8110786/05cba030-7be9-4028-b698-8dc80522a218 | https://github.com/react-native-menu/menu/assets/8110786/81412978-bba7-45be-ba10-c17a387cfc11 | 
