### PR TITLE
Fix missing subtitles on iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -343,7 +343,7 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-menu (0.8.0):
+  - react-native-menu (0.9.1):
     - React
   - React-NativeModulesApple (0.72.4):
     - React-callinvoker
@@ -666,7 +666,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: bc8a9ad812a2c88b3a41c08b5f4b3ed32d6d4766
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-menu: 5b9b82dabcc779cebde15d292ccbcba4469ff311
+  react-native-menu: 9728f90160c36b9a75481fc76e05354b99d54c59
   React-NativeModulesApple: 759309419da76ef4c9f331968b840022ee2aa5b1
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00

--- a/ios/RCTMenuItem.swift
+++ b/ios/RCTMenuItem.swift
@@ -95,6 +95,11 @@ class RCTMenuAction {
                 return UIMenu(title: title, image: image, children: subMenuActions)
             }
         }
-        return UIAction(title: title, image: image, identifier: identifier, discoverabilityTitle: subtitle, attributes: attributes, state: state, handler: handler)
+
+        if #available(iOS 15, *) {
+            return UIAction(title: title, subtitle: subtitle, image: image, identifier: identifier, attributes: attributes, state: state, handler: handler)
+        } else {
+            return UIAction(title: title, image: image, identifier: identifier, discoverabilityTitle: subtitle, attributes: attributes, state: state, handler: handler)
+        }
     }
 }


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

As of iOS 15, `discoverabilityTitle` is no longer displayed as the subtitle UIActions. Subtitles are not visible to iOS users of this package. This update brings them back.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

WIP


Fixes: https://github.com/react-native-menu/menu/issues/536