### PR TITLE
[android] fix: use hitSlop setter instead of property access for RN 0.74 compatibility

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
@@ -110,13 +110,13 @@ class MenuViewManager: ReactClippingViewManager<MenuView>() {
   @ReactProp(name = "hitSlop")
   fun setHitSlop(view: ReactViewGroup, @Nullable hitSlop: ReadableMap?) {
     if (hitSlop == null) {
-      view.hitSlopRect = null
+      view.setHitSlopRect(null)
     } else {
-      view.hitSlopRect = Rect(
+      view.setHitSlopRect(Rect(
         if (hitSlop.hasKey("left")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")).toInt() else 0,
         if (hitSlop.hasKey("top")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")).toInt() else 0,
         if (hitSlop.hasKey("right")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")).toInt() else 0,
-        if (hitSlop.hasKey("bottom")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")).toInt() else 0)
+        if (hitSlop.hasKey("bottom")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")).toInt() else 0))
     }
   }
 


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

Fixes https://github.com/react-native-menu/menu/issues/736

Not sure why, but it seems like RN 0.74 (or newer Kotlin compiler) is more strict in terms of value reassignment. While in the past we were able to use direct property access on the `view` argument, it seems like now we have to use usual property setters.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

The app compiles successfully.

**Note**: there's still work to be done for bringing bridgeless compatbility to this library's Android side (maybe iOS as well). Namely, the current way of sending events doesn't seem to work on bridgeless, see: https://github.com/reactwg/react-native-new-architecture/discussions/154#discussioncomment-9082416

Do you have any insight on what could be the culprit and how to fix this?
