### PR TITLE
[Android] Move to EventDispatcher instead of RCTEventEmitter

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuOnPressActionEvent.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuOnPressActionEvent.kt
@@ -1,0 +1,21 @@
+package com.reactnativemenu
+
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+
+class MenuOnPressActionEvent(
+  surfaceId: Int,
+  viewTag: Int,
+  private val event: String?,
+  private val target: Int
+) : Event<MenuOnPressActionEvent>(surfaceId, viewTag) {
+
+  override fun getEventName(): String = "onPressAction"
+  override fun getEventData(): WritableMap = Arguments.createMap().apply {
+    if (event != null) {
+      putString("event", event)
+    }
+    putString("target", target.toString())
+  }
+}

--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -10,6 +10,8 @@ import android.text.style.ForegroundColorSpan
 import android.view.*
 import android.widget.PopupMenu
 import com.facebook.react.bridge.*
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.facebook.react.views.view.ReactViewGroup
 import java.lang.reflect.Field
@@ -165,14 +167,14 @@ class MenuView(private val mContext: ReactContext): ReactViewGroup(mContext) {
             subMenuItem.setOnMenuItemClickListener {
               if (!it.hasSubMenu()) {
                 mIsMenuDisplayed = false
-                val args: WritableMap = Arguments.createMap()
                 if (!subactions.isNull(it.order)) {
                   val selectedItem = subactions.getMap(it.order)
-                  args.putString("event", selectedItem?.getString("id"))
-                  args.putString("target", "$id")
-                  mContext
-                    .getJSModule(RCTEventEmitter::class.java)
-                    .receiveEvent(id, "onPressAction", args)
+                  val dispatcher =
+                    UIManagerHelper.getEventDispatcherForReactTag(mContext, id)
+                  val surfaceId: Int = UIManagerHelper.getSurfaceId(this)
+                  dispatcher?.dispatchEvent(
+                    MenuOnPressActionEvent(surfaceId, id, selectedItem.getString("id"), id)
+                  )
                 }
                 true
               } else {
@@ -210,14 +212,14 @@ class MenuView(private val mContext: ReactContext): ReactViewGroup(mContext) {
           menuItem.setOnMenuItemClickListener {
             if (!it.hasSubMenu()) {
               mIsMenuDisplayed = false
-              val args: WritableMap = Arguments.createMap()
               if (!mActions.isNull(it.order)) {
                 val selectedItem = mActions.getMap(it.order)
-                args.putString("event", selectedItem?.getString("id"))
-                args.putString("target", "$id")
-                mContext
-                  .getJSModule(RCTEventEmitter::class.java)
-                  .receiveEvent(id, "onPressAction", args)
+                val dispatcher =
+                  UIManagerHelper.getEventDispatcherForReactTag(mContext, id)
+                val surfaceId: Int = UIManagerHelper.getSurfaceId(this)
+                dispatcher?.dispatchEvent(
+                  MenuOnPressActionEvent(surfaceId, id, selectedItem.getString("id"), id)
+                )
               }
               true
             } else {


### PR DESCRIPTION
# Overview

This is an example of how you should use `EventDispatcher` rather than `RCTEventEmitter` for event dispatching on Android (both old and new architecture).

# Test Plan

I haven't tested this yet.