### PR TITLE
fix: repo scripts launch test app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,19 +15,19 @@ While developing, you can run the [example app](/example/) to test your changes.
 To start the packager:
 
 ```sh
-yarn example start
+yarn start
 ```
 
 To run the example app on Android:
 
 ```sh
-yarn example android
+yarn android
 ```
 
 To run the example app on iOS:
 
 ```sh
-yarn example ios
+yarn ios
 ```
 
 Make sure your code passes TypeScript and ESLint. Run the following to verify:
@@ -82,9 +82,9 @@ The `package.json` file contains various scripts for common tasks:
 - `yarn typescript`: type-check files with TypeScript.
 - `yarn lint`: lint files with ESLint.
 - `yarn test`: run unit tests with Jest.
-- `yarn example start`: start the Metro server for the example app.
-- `yarn example android`: run the example app on Android.
-- `yarn example ios`: run the example app on iOS.
+- `yarn start`: start the Metro server for the example app.
+- `yarn android`: run the example app on Android.
+- `yarn ios`: run the example app on iOS.
 
 ### Sending a pull request
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -9,7 +9,8 @@
 .xcode.env
 Pods/
 build/
-dist/
+dist/*
+!dist/.gitignore
 local.properties
 msbuild.binlog
 node_modules/

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,6 +1,14 @@
 buildscript {
-    def androidTestAppDir = "../node_modules/react-native-test-app/android"
-    apply(from: "${androidTestAppDir}/dependencies.gradle")
+    apply(from: {
+        def searchDir = rootDir.toPath()
+        do {
+            def p = searchDir.resolve("node_modules/react-native-test-app/android/dependencies.gradle")
+            if (p.toFile().exists()) {
+                return p.toRealPath().toString()
+            }
+        } while (searchDir = searchDir.getParent())
+        throw new GradleException("Could not find `react-native-test-app`");
+    }())
 
     repositories {
         mavenCentral()
@@ -18,7 +26,16 @@ allprojects {
     repositories {
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-            url("${rootDir}/../node_modules/react-native/android")
+            url({
+                def searchDir = rootDir.toPath()
+                do {
+                    def p = searchDir.resolve("node_modules/react-native/android")
+                    if (p.toFile().exists()) {
+                        return p.toRealPath().toString()
+                    }
+                } while (searchDir = searchDir.getParent())
+                throw new GradleException("Could not find `react-native`");
+            }())
         }
         mavenCentral()
         google()

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -8,5 +8,14 @@ pluginManagement {
 
 rootProject.name = "MenuExample"
 
-apply(from: "../node_modules/react-native-test-app/test-app.gradle")
+apply(from: {
+    def searchDir = rootDir.toPath()
+    do {
+        def p = searchDir.resolve("node_modules/react-native-test-app/test-app.gradle")
+        if (p.toFile().exists()) {
+            return p.toRealPath().toString()
+        }
+    } while (searchDir = searchDir.getParent())
+    throw new GradleException("Could not find `react-native-test-app`");
+}())
 applyTestAppSettings(settings)

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   ],
   "scripts": {
     "android": "react-native run-android",
-    "bootstrap": "yarn && yarn example && yarn pods",
-    "example": "yarn --cwd example",
+    "bootstrap": "yarn && yarn pods",
     "format": "prettier --write \"**/*.{js,ts,tsx}\"",
     "ios": "react-native run-ios",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
     "!**/__mocks__"
   ],
   "scripts": {
+    "android": "react-native run-android",
     "bootstrap": "yarn && yarn example && yarn pods",
     "example": "yarn --cwd example",
     "format": "prettier --write \"**/*.{js,ts,tsx}\"",
+    "ios": "react-native run-ios",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "pods": "cd example && pod-install --quiet",
     "prepare": "bob build",
     "release": "release-it",
-    "start": "cd example && react-native start",
+    "start": "react-native start",
     "test": "jest",
     "typescript": "tsc --noEmit"
   },


### PR DESCRIPTION
# Overview

After #748 , I removed the `package.json` in the `example` folder, and refactored `react-native.config` and `metro.config` so that we can run the example app from the root of the repo. I didn't update the scripts and README, this PR does that.

# Test Plan

`yarn android` works
