### PR TITLE
feat(iOS): preferredElementSize

### DIFF
--- a/ios/Shared/RCTMenuItem.swift
+++ b/ios/Shared/RCTMenuItem.swift
@@ -18,6 +18,8 @@ class RCTMenuAction {
     var attributes: UIAction.Attributes = []
     var state: UIAction.State = .off
     var subactions: [RCTMenuAction] = []
+    // Only available in iOS 16+
+    var preferredElementSizeString: String?
 
     init(details: NSDictionary){
 
@@ -83,6 +85,9 @@ class RCTMenuAction {
             }
         }
 
+        if let preferredElementSizeString = details["preferredElementSize"] as? String {
+            self.preferredElementSizeString = preferredElementSizeString
+        }
 
     }
 
@@ -92,11 +97,24 @@ class RCTMenuAction {
             subactions.forEach { subaction in
                 subMenuActions.append(subaction.createUIMenuElement(handler))
             }
+            var menu: UIMenu;
             if self.displayInline {
-                return UIMenu(title: title, image: image, options: .displayInline, children: subMenuActions)
+                menu = UIMenu(title: title, image: image, options: .displayInline, children: subMenuActions)
             } else {
-                return UIMenu(title: title, image: image, children: subMenuActions)
+                menu = UIMenu(title: title, image: image, children: subMenuActions)
             }
+
+            if #available(iOS 16.0, *) {
+                if(preferredElementSizeString == "small") {
+                    menu.preferredElementSize = .small
+                } else if(preferredElementSizeString == "medium") {
+                    menu.preferredElementSize = .medium
+                } else if(preferredElementSizeString == "large") {
+                    menu.preferredElementSize = .large
+                }
+            }
+
+            return menu
         }
 
         if #available(iOS 15, *) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,13 @@ export type MenuAction = {
   /**
    * Whether subactions should be inline (separated by divider) or nested (sub menu)
    */
-  displayInline?: boolean;
+  displayInline?: boolean;  
+  /**
+  * (iOS 16+ only)
+  * The preferred size of this menu's child elements.
+  * @platform iOS
+  */
+  preferredElementSize?: 'small' | 'medium' | 'large';
 };
 
 type MenuComponentPropsBase = {


### PR DESCRIPTION
# Overview

Support for preferredElementSize, which enables horizontal UIElements within a UIMenu

<img width="655" alt="Screenshot 2024-05-03 at 11 55 56" src="https://github.com/react-native-menu/menu/assets/12223738/ded5fe01-4e8c-4f6f-a975-ef96478964d9">
