### PR TITLE
Change incorrect OLD_ARCH header import

### DIFF
--- a/ios/MenuViewManager.mm
+++ b/ios/MenuViewManager.mm
@@ -7,7 +7,7 @@
 #import "MenuView.h"
 #else
 // OLD ARCH
-#import <react_native_menu/react_native_menu-Swift.h>
+#import <react_native_menu-Swift.h>
 #endif
 
 @interface MenuViewManager : RCTViewManager


### PR DESCRIPTION
# Overview

The import was set incorrectly for `OLD_ARCH` which leads to project's failing build.

# Test Plan

Build an iOS project with `OLD_ARCH`.
