### PR TITLE
Update README's title usage according to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ const App = () => {
         actions={[
           {
             id: 'add',
+            title: 'Add',
             titleColor: '#2367A2',
             image: Platform.select({
               ios: 'plus',
@@ -144,7 +145,7 @@ The title of the menu.
 
 | Type   | Required |
 | ------ | -------- |
-| string | No       |
+| string | Yes      |
 
 ### `isAnchoredToRight` (Android only)
 


### PR DESCRIPTION
# Overview

Based on TypeScript's types`, `title` is a required field in `MenuAction`, while `README` says that its non-required, this PR changes `README` according to types.
