### PR TITLE
eat: updated minSdkVersion to sdk version 23, inline with react-native's 0.74.0 minSdkVersion

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 23
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     versionCode 1

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 Menu_kotlinVersion=1.7.0
-Menu_minSdkVersion=21
+Menu_minSdkVersion=23
 Menu_targetSdkVersion=31
 Menu_compileSdkVersion=31
 Menu_ndkversion=21.4.7075529


### PR DESCRIPTION
# Overview

This PR bumps the `minSdkVersion` to `23`, following the bump made by the react native team in `react-native@0.74` ([see release notes](https://reactnative.dev/blog/2024/04/22/release-0.74#android-minimum-sdk-bump-android-60). 

Solved #802 
