### PR TITLE
docs: document declarative way of use

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ const App = () => {
 };
 ```
 
+### Declarative usage
+
+It's also possible to obtain the `action` is a more React-ish, declarative fashion. Refer to the [`react-to-imperative`](https://github.com/vonovak/react-to-imperative?tab=readme-ov-file#why) package, and see an example [here](https://github.com/vonovak/react-navigation-header-buttons/blob/cca6ce6d04d3b106efe7aa62279101db33c7941b/example/src/screens/UsageNativeMenu.tsx#L62).
+
 ## Reference
 
 ### Props


### PR DESCRIPTION
# Overview

Hello and thanks for this package! While working on another lib, I created a package that can "convert" declarative stuff (React) for imperative use. Maybe it'll be useful to others too.

The idea is that you can take components 

```
function WrappedButton({ title, onPress }: WrappedButtonProps) {
  return <button onClick={onPress}>{title}</button>;
}
function DoubleWrappedButton(props: WrappedButtonProps) {
  return <WrappedButton {...props} />;
}


it('works for single child element', () => {
  const props = { title: 'one', onPress: jest.fn() };
  const propsTwo = { title: 'two', onPress: jest.fn() };
  expect(extractProps(<WrappedButton {...props} />)).toStrictEqual([props]);
  expect(extractProps(<DoubleWrappedButton {...propsTwo} />)).toStrictEqual([
    propsTwo,
  ]);
});
```

and get out the props you provided to them, without rendering the components. This way you can obtain the value for the `actions` prop from React components. The motivation here https://github.com/vonovak/react-to-imperative/tree/main?tab=readme-ov-file#why explains it. Hope this makes sense! :)
