### PR TITLE
fix: Fix `<react_native_menu/react_native_menu-Swift.h>` not found on old arch

### DIFF
--- a/ios/MenuViewManager.mm
+++ b/ios/MenuViewManager.mm
@@ -7,7 +7,12 @@
 #import "MenuView.h"
 #else
 // OLD ARCH
+#if __has_include(<react_native_menu/react_native_menu-Swift.h>)
 #import <react_native_menu/react_native_menu-Swift.h>
+#else
+#import <react_native_menu-Swift.h>
+#endif
+
 #endif
 
 @interface MenuViewManager : RCTViewManager


### PR DESCRIPTION


The PR https://github.com/react-native-menu/menu/pull/807 broke the build for me on RN 0.74, latest Xcode / macOS.

Instead of just reverting it, I now check for both includes to see which one works, then use that.
