### PR TITLE
Fix building on iOS on react-native@0.74.1 newArchEnabled and static frameworks

### DIFF
--- a/ios/NewArch/MenuView.mm
+++ b/ios/NewArch/MenuView.mm
@@ -1,5 +1,9 @@
 #ifdef RCT_NEW_ARCH_ENABLED
+#if __has_include(<react_native_menu/react_native_menu-Swift.h>)
+#import <react_native_menu/react_native_menu-Swift.h>
+#else
 #import <react_native_menu-Swift.h>
+#endif
 #import "MenuView.h"
 
 #import <react/renderer/components/RNMenuViewSpec/ComponentDescriptors.h>


### PR DESCRIPTION
It fails to make a build with react-native@0.74.1, newArchEnabled = true and useFrameworks = "static"

The error is as shown below

`Compiling @react-native-menu/menu Pods/react-native-menu » MenuViewManager.mm › Compiling @react-native-menu/menu Pods/react-native-menu » MenuView.mm`

```
❌  (node_modules/@react-native-menu/menu/ios/NewArch/MenuView.mm:2:9)

  1 | #ifdef RCT_NEW_ARCH_ENABLED
> 2 | #import <react_native_menu-Swift.h>
    |         ^ 'react_native_menu-Swift.h' file not found
  3 | #import "MenuView.h"
  4 | 
  5 | #import <react/renderer/components/RNMenuViewSpec/ComponentDescriptors.h>
```

I am using @react-native-menu/menu@1.1.2

The same solution has been applied in https://github.com/react-native-menu/menu/pull/807 and should also fix https://github.com/react-native-menu/menu/issues/801. 
