### PR TITLE
Remove the Fabric instructions from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,6 @@ The package is [automatically linked](https://github.com/react-native-community/
 npx pod-install
 ```
 
-## Fabric
-
-If you plan on using fabric with this project, you may want to add the following lines on your projects' Podfile:
-
-```ruby
-+    # @react-native-menu/menu (fabric+swift requirements)
-+    pod 'React-Fabric', :modular_headers => true, :path => '../node_modules/react-native/ReactCommon'
-+    pod 'React-graphics', :modular_headers => true, :path => '../node_modules/react-native/ReactCommon/react/renderer/graphics'
-+    pod 'React-utils', :modular_headers => true, :path => '../node_modules/react-native/ReactCommon/react/utils'
-+    pod 'React-debug', :modular_headers => true, :path => '../node_modules/react-native/ReactCommon/react/debug'
-```
-
 ## Usage
 
 ```jsx


### PR DESCRIPTION
# Overview

These changes don't appear to be required.

# Test Plan

I created a new app with `npx create-expo-app`, [enabled the New Architecture](https://docs.expo.dev/guides/new-architecture/#enable-the-new-architecture-in-an-existing-project), installed `@react-native-menu/menu`, copied over the example from the README, then compiled and ran the project with `npx expo run:ios` - it worked as expected.
