### PR TITLE
Add hitSlop support (#627)

### DIFF
--- a/ios/MenuViewManager.mm
+++ b/ios/MenuViewManager.mm
@@ -66,4 +66,9 @@ RCT_EXPORT_VIEW_PROPERTY(shouldOpenOnLongPress, BOOL)
  */
 RCT_EXPORT_VIEW_PROPERTY(themeVariant, NSString)
 
+/**
+ * hitSlop: The same as hitSlop in React Native
+*/
+RCT_EXPORT_VIEW_PROPERTY(hitSlop, UIEdgeInsets)
+
 @end

--- a/ios/Shared/MenuViewImplementation.swift
+++ b/ios/Shared/MenuViewImplementation.swift
@@ -50,6 +50,8 @@ public class MenuViewImplementation: UIButton {
         }
     }
 
+    @objc var hitSlop: UIEdgeInsets = .zero
+
     override init(frame: CGRect) {
       super.init(frame: frame)
       self.setup()
@@ -76,6 +78,23 @@ public class MenuViewImplementation: UIButton {
     public override func reactSetFrame(_ frame: CGRect) {
       super.reactSetFrame(frame);
     };
+
+    public override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        if hitSlop == .zero || !self.isEnabled || self.isHidden {
+            return super.point(inside: point, with: event)
+        }
+
+        // Create a larger hit frame that extends beyond the view's bounds
+        let largerFrame = CGRect(
+            x: self.bounds.origin.x - hitSlop.left,
+            y: self.bounds.origin.y - hitSlop.top,
+            width: self.bounds.size.width + hitSlop.left + hitSlop.right,
+            height: self.bounds.size.height + hitSlop.top + hitSlop.bottom
+        )
+
+        // Check if the point is within the larger frame
+        return largerFrame.contains(point)
+    }
 
 
   required init?(coder aDecoder: NSCoder) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,9 @@ function processAction(action: MenuAction): ProcessedMenuAction {
   };
 }
 
-const MenuView: React.FC<MenuComponentProps> = ({ actions, ...props }) => {
+const defaultHitslop = { top: 0, left: 0, bottom: 0, right: 0 };
+
+const MenuView: React.FC<MenuComponentProps> = ({ actions, hitSlop = defaultHitslop, ...props }) => {
   const processedActions = actions.map<ProcessedMenuAction>((action) =>
     processAction(action)
   );
@@ -27,7 +29,7 @@ const MenuView: React.FC<MenuComponentProps> = ({ actions, ...props }) => {
     return objectHash(processedActions);
   }, [processedActions]);
   return (
-    <UIMenuView {...props} actions={processedActions} actionsHash={hash} />
+    <UIMenuView {...props} hitSlop={hitSlop} actions={processedActions} actionsHash={hash} />
   );
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,16 @@ type MenuComponentPropsBase = {
    * @platform iOS
    */
   themeVariant?: string;
+  /**
+   * Custom OpenSpace hitSlop prop. Works like touchable hitslop.
+   * @platform iOS
+   */
+  hitSlop?: {
+    top: number;
+    bottom: number;
+    left: number;
+    right: number;
+  };
 };
 
 export type MenuComponentProps =
@@ -164,4 +174,5 @@ export type NativeMenuComponentProps = {
   actions: ProcessedMenuAction[];
   actionsHash: string;
   title?: string;
+  hitSlop?: MenuComponentProps['hitSlop'];
 };


### PR DESCRIPTION
# Overview

Adds the `hitSlop` parameter to the menu component so that small buttons can still be pressed.

Contains @thomasttvo's changes from #627, updated for the latest version of the library.

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->