### PR TITLE
fix: Remove custom logic for extracting RGB and alpha components for setBorderColor

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
@@ -152,9 +152,7 @@ class MenuViewManager: ReactClippingViewManager<MenuView>() {
 
   @ReactPropGroup(names = [ViewProps.BORDER_COLOR, ViewProps.BORDER_LEFT_COLOR, ViewProps.BORDER_RIGHT_COLOR, ViewProps.BORDER_TOP_COLOR, ViewProps.BORDER_BOTTOM_COLOR, ViewProps.BORDER_START_COLOR, ViewProps.BORDER_END_COLOR], customType = "Color")
   fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?) {
-    val rgbComponent = if (color == null) YogaConstants.UNDEFINED else (color and 0x00FFFFFF).toFloat()
-    val alphaComponent = if (color == null) YogaConstants.UNDEFINED else (color ushr 24).toFloat()
-    view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent)
+    view.setBorderColor(index, color)
   }
 
   @ReactProp(name = ViewProps.OVERFLOW)


### PR DESCRIPTION
# Overview

Upgrading React Native to 0.76 causes a build crash due to a change in the signature of setBorderColor in version 0.76 ([ReactViewGroup.java](https://github.com/facebook/react-native/blob/2e10ba945f6f2dca8d8cf1bb0db1d67fd50f2235/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java#L345)).

This PR introduced the new signature: https://github.com/facebook/react-native/commit/58c726a6bade42946cc28191de5f7ddb109d63f0

You can see the relevant diff here: https://github.com/facebook/react-native/commit/58c726a6bade42946cc28191de5f7ddb109d63f0#diff-0830ad3c2f92a395a52a1175e0868ce8c7f195ca2a95958e932077d00dd79021L308.

With this change, we no longer need to extract the RGB and alpha components; we can now directly pass the color.
