### PR TITLE
fix(android): hit slop functionality

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManager.kt
@@ -110,13 +110,13 @@ class MenuViewManager: ReactClippingViewManager<MenuView>() {
   @ReactProp(name = "hitSlop")
   fun setHitSlop(view: ReactViewGroup, @Nullable hitSlop: ReadableMap?) {
     if (hitSlop == null) {
-      view.setHitSlopRect(null)
+      view.hitSlopRect = null
     } else {
-      view.setHitSlopRect(Rect(
-        if (hitSlop.hasKey("left")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")).toInt() else 0,
-        if (hitSlop.hasKey("top")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")).toInt() else 0,
-        if (hitSlop.hasKey("right")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")).toInt() else 0,
-        if (hitSlop.hasKey("bottom")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")).toInt() else 0))
+      view.hitSlopRect = Rect(
+          if (hitSlop.hasKey("left")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")).toInt() else 0,
+          if (hitSlop.hasKey("top")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")).toInt() else 0,
+          if (hitSlop.hasKey("right")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")).toInt() else 0,
+          if (hitSlop.hasKey("bottom")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")).toInt() else 0)
     }
   }
 


### PR DESCRIPTION
# Add Hit Slop Support for MenuView on Android

This PR adds support for hit slop on the MenuView component for Android, improving touch responsiveness and user experience.

## Changes

### MenuView.kt

- Added `mHitSlopRect` property to store the hit slop rectangle
- Implemented `setHitSlopRect` method to update the hit slop and trigger touch delegate update
- Added `onSizeChanged` and `onAttachedToWindow` overrides to update touch delegate
- Implemented `updateTouchDelegate` method to apply hit slop and set touch delegate

## Testing

Please test the following scenarios:

1. Menu opens correctly with default touch area
2. Menu opens correctly when hit slop is applied
3. Hit slop works as expected for all sides (left, top, right, bottom)
4. Touch delegate updates properly when view size changes or when attached to window

## Notes

This implementation enhances the touch area of the MenuView component, making it easier for users to interact with the menu, especially on smaller devices or for users with accessibility needs.