### PR TITLE
Add Version-Specific Kotlin Implementations for Android to Support React Native 0.76+ and lower

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,19 @@ To edit the Objective-C files, open `example/ios/MenuExample.xcworkspace` in XCo
 
 To edit the Kotlin files, open `example/android` in Android studio and find the source files at `reactnativemenu` under `Android`.
 
+### Versioning in `MenuViewManager`
+
+As of the latest update, `com.reactnativemenu.MenuViewManager` has been refactored into an abstract base class, `MenuViewManagerBase`. Any React Native version-dependent changes should be implemented in the specific version folders under `reactNativeVersionPatch`.
+
+For consistency:
+- When making version-specific modifications, ensure you update the appropriate implementation of `MenuViewManager`:
+  - `src/reactNativeVersionPatch/75/MenuViewManager.kt` for React Native < 0.76
+  - `src/reactNativeVersionPatch/latest/MenuViewManager.kt` for React Native >= 0.76
+- If adding a new file that depends on React Native version, create folders under `reactNativeVersionPatch` for both `75` and `latest` and include the version-specific implementations there.
+- Update `build.gradle` to include the new file in the `sourceSets`, so it’s dynamically selected based on the React Native version.
+
+This approach ensures consistent version handling and clean separation of code across versions.
+
 ### Commit message convention
 
 We follow the [conventional commits specification](https://www.conventionalcommits.org/en) for our commit messages:
@@ -97,6 +110,7 @@ When you're sending a pull request:
 - Review the documentation to make sure it looks good.
 - Follow the pull request template when opening a pull request.
 - For pull requests that change the API or implementation, discuss with maintainers first by opening an issue.
+- For version-dependent changes, follow the versioning structure for `MenuViewManager` outlined in the **Versioning in `MenuViewManager`** section. Ensure all version-specific files are included in `reactNativeVersionPatch` and referenced in `build.gradle`.
 
 ## Code of Conduct
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,10 @@ def getExtOrIntegerDefault(name) {
   return rootProject.ext.has(name) ? rootProject.ext.get(name) : (project.properties["Menu_" + name]).toInteger()
 }
 
+def getExtOrFallback(name, fallback) {
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : fallback
+}
+
 def supportsNamespace() {
   def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
   def major = parsed[0].toInteger()
@@ -40,6 +44,35 @@ def supportsNamespace() {
 
   // Namespace support was added in 7.3.0
   return (major == 7 && minor >= 3) || major >= 8
+}
+
+def resolveReactNativeDirectory() {
+    def reactNativeLocation = getExtOrFallback("REACT_NATIVE_NODE_MODULES_DIR", null)
+    if (reactNativeLocation != null) {
+        return file(reactNativeLocation)
+    }
+
+    // monorepo workaround.
+    def reactNativePackage = file(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim())
+    if(reactNativePackage.exists()) {
+        return reactNativePackage.parentFile
+    }
+
+    throw new GradleException(
+        "[@react-native-menu/menu] Unable to resolve react-native location in node_modules. You should project extension property (in `app/build.gradle`) `REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+    )
+}
+
+def getReactNativeMinorVersion() {
+  def REACT_NATIVE_DIR = resolveReactNativeDirectory()
+
+  def reactProperties = new Properties()
+  file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
+
+  def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
+  def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
+
+  return REACT_NATIVE_MINOR_VERSION
 }
 
 android {
@@ -92,6 +125,13 @@ android {
         ]
       } else {
         java.srcDirs += ["src/oldarch"]
+      }
+
+      // MenuViewManager
+      if (getReactNativeMinorVersion() <= 75) {
+        java.srcDirs += "src/reactNativeVersionPatch/MenuViewManager/75"
+      } else {
+        java.srcDirs += "src/reactNativeVersionPatch/MenuViewManager/latest"
       }
     }
   }

--- a/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
@@ -17,7 +17,7 @@ import com.facebook.react.views.view.ReactDrawableHelper
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.yoga.YogaConstants
 
-class MenuViewManager: ReactClippingViewManager<MenuView>() {
+abstract class MenuViewManagerBase: ReactClippingViewManager<MenuView>() {
   override fun getName() = "MenuView"
 
   override fun createViewInstance(reactContext: ThemedReactContext): MenuView {
@@ -151,9 +151,7 @@ class MenuViewManager: ReactClippingViewManager<MenuView>() {
   }
 
   @ReactPropGroup(names = [ViewProps.BORDER_COLOR, ViewProps.BORDER_LEFT_COLOR, ViewProps.BORDER_RIGHT_COLOR, ViewProps.BORDER_TOP_COLOR, ViewProps.BORDER_BOTTOM_COLOR, ViewProps.BORDER_START_COLOR, ViewProps.BORDER_END_COLOR], customType = "Color")
-  fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?) {
-    view.setBorderColor(index, color)
-  }
+  abstract fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?)
 
   @ReactProp(name = ViewProps.OVERFLOW)
   fun setOverflow(view: ReactViewGroup, overflow: String?) {

--- a/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
@@ -20,10 +20,6 @@ import com.facebook.yoga.YogaConstants
 abstract class MenuViewManagerBase: ReactClippingViewManager<MenuView>() {
   override fun getName() = "MenuView"
 
-  override fun createViewInstance(reactContext: ThemedReactContext): MenuView {
-    return MenuView(reactContext)
-  }
-
   @ReactProp(name = "actions")
   fun setActions(view: MenuView, actions: ReadableArray) {
     view.setActions(actions)

--- a/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuViewManagerBase.kt
@@ -106,13 +106,14 @@ abstract class MenuViewManagerBase: ReactClippingViewManager<MenuView>() {
   @ReactProp(name = "hitSlop")
   fun setHitSlop(view: ReactViewGroup, @Nullable hitSlop: ReadableMap?) {
     if (hitSlop == null) {
-      view.hitSlopRect = null
+      // We should keep using setters as `Val cannot be reassigned`
+      view.setHitSlopRect(null)
     } else {
-      view.hitSlopRect = Rect(
-          if (hitSlop.hasKey("left")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")).toInt() else 0,
-          if (hitSlop.hasKey("top")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")).toInt() else 0,
-          if (hitSlop.hasKey("right")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")).toInt() else 0,
-          if (hitSlop.hasKey("bottom")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")).toInt() else 0)
+      view.setHitSlopRect(Rect(
+        if (hitSlop.hasKey("left")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("left")).toInt() else 0,
+        if (hitSlop.hasKey("top")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("top")).toInt() else 0,
+        if (hitSlop.hasKey("right")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("right")).toInt() else 0,
+        if (hitSlop.hasKey("bottom")) PixelUtil.toPixelFromDIP(hitSlop.getDouble("bottom")).toInt() else 0))
     }
   }
 

--- a/android/src/reactNativeVersionPatch/MenuViewManager/75/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/reactNativeVersionPatch/MenuViewManager/75/com/reactnativemenu/MenuViewManager.kt
@@ -1,8 +1,13 @@
 package com.reactnativemenu
 
 import com.facebook.react.views.view.ReactViewGroup
+import com.facebook.yoga.YogaConstants
+import com.facebook.react.uimanager.ThemedReactContext
 
 class MenuViewManager : MenuViewManagerBase() {
+  override fun createViewInstance(reactContext: ThemedReactContext): MenuView {
+    return MenuView(reactContext)
+  }
 
   override fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?) {
     val rgbComponent = color?.let { (it and 0x00FFFFFF).toFloat() } ?: YogaConstants.UNDEFINED

--- a/android/src/reactNativeVersionPatch/MenuViewManager/75/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/reactNativeVersionPatch/MenuViewManager/75/com/reactnativemenu/MenuViewManager.kt
@@ -1,0 +1,12 @@
+package com.reactnativemenu
+
+import com.facebook.react.views.view.ReactViewGroup
+
+class MenuViewManager : MenuViewManagerBase() {
+
+  override fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?) {
+    val rgbComponent = color?.let { (it and 0x00FFFFFF).toFloat() } ?: YogaConstants.UNDEFINED
+    val alphaComponent = color?.let { (it ushr 24).toFloat() } ?: YogaConstants.UNDEFINED
+    view.setBorderColor(SPACING_TYPES[index], rgbComponent, alphaComponent)
+  }
+}

--- a/android/src/reactNativeVersionPatch/MenuViewManager/latest/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/reactNativeVersionPatch/MenuViewManager/latest/com/reactnativemenu/MenuViewManager.kt
@@ -1,0 +1,10 @@
+package com.reactnativemenu
+
+import com.facebook.react.views.view.ReactViewGroup
+
+class MenuViewManager : MenuViewManagerBase() {
+
+  override fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?) {
+    view.setBorderColor(index, color)
+  }
+}

--- a/android/src/reactNativeVersionPatch/MenuViewManager/latest/com/reactnativemenu/MenuViewManager.kt
+++ b/android/src/reactNativeVersionPatch/MenuViewManager/latest/com/reactnativemenu/MenuViewManager.kt
@@ -1,8 +1,12 @@
 package com.reactnativemenu
 
 import com.facebook.react.views.view.ReactViewGroup
+import com.facebook.react.uimanager.ThemedReactContext
 
 class MenuViewManager : MenuViewManagerBase() {
+  override fun createViewInstance(reactContext: ThemedReactContext): MenuView {
+    return MenuView(reactContext)
+  }
 
   override fun setBorderColor(view: ReactViewGroup, index: Int, color: Int?) {
     view.setBorderColor(index, color)


### PR DESCRIPTION
# Overview

## Summary
The previous PR introduced a fix for React Native 0.76 compatibility but inadvertently broke support for earlier React Native versions https://github.com/react-native-menu/menu/pull/941. This PR restructures the Android implementation to support multiple versions of React Native by providing separate Kotlin class implementations based on the React Native version in use.

## Main changes:
- **Version-Specific Implementations**: Added a new folder, `android/src/reactNativeVersionPatch`, to store version-specific implementations of classes, ensuring compatibility across different React Native versions.
- **Gradle Build Updates**: Updated `build.gradle` to import the files from `reactNativeVersionPatch`, streamlining the integration of version-dependent classes.
- **MenuViewManager Refactor**: Refactored `MenuViewManager` into an abstract class that now delegates to `MenuViewManagerBase`. This refactor enables importing the appropriate `MenuViewManager` based on the current React Native version.
- **Documentation Update**: Revised `CONTRIBUTING.md` to outline the compatibility approach for version 0.76. The guide now suggests converting existing classes to abstract and implementing them for both 0.75 and the latest version. The naming convention used here (75 for the stable codebase supporting versions <0.76 and latest for versions >=0.76) can be adjusted as needed.
- **Bug Fix**: Replaced reassignment of `view.hitSlopRect` with the setter `view.setHitSlopRect` to prevent the "Val cannot be reassigned" error. https://github.com/react-native-menu/menu/pull/942
