### PR TITLE
fix(iOS): new architecture props

### DIFF
--- a/ios/NewArch/FabricViewImplementationProtocol.swift
+++ b/ios/NewArch/FabricViewImplementationProtocol.swift
@@ -2,5 +2,8 @@ import Foundation
 @objc public protocol FabricViewImplementationProtocol {
     var actions: [NSDictionary]? { get set }
     var title: NSString? { get set }
+    var themeVariant: NSString? { get set }
+    var shouldOpenOnLongPress: Bool { get set }
+    @objc optional var hitSlop: UIEdgeInsets { get set }
     var onPressAction: ((String) -> Void)? { get set }
 }

--- a/ios/NewArch/MenuView.mm
+++ b/ios/NewArch/MenuView.mm
@@ -137,6 +137,26 @@ using namespace facebook::react;
         _view.title = [NSString stringWithUTF8String:newViewProps.title.c_str()];
     }
 
+    if (oldViewProps.themeVariant != newViewProps.themeVariant) {
+        _view.themeVariant = [NSString stringWithUTF8String:newViewProps.themeVariant.c_str()];
+    }
+    
+    if (oldViewProps.shouldOpenOnLongPress != newViewProps.shouldOpenOnLongPress) {
+        _view.shouldOpenOnLongPress = newViewProps.shouldOpenOnLongPress;
+    }
+
+    if (oldViewProps.hitSlop.top != newViewProps.hitSlop.top ||
+        oldViewProps.hitSlop.bottom != newViewProps.hitSlop.bottom ||
+        oldViewProps.hitSlop.left != newViewProps.hitSlop.left ||
+        oldViewProps.hitSlop.right != newViewProps.hitSlop.right) {
+        _view.hitSlop = UIEdgeInsetsMake(
+            newViewProps.hitSlop.top,
+            newViewProps.hitSlop.left,
+            newViewProps.hitSlop.bottom,
+            newViewProps.hitSlop.right
+        );
+    }
+
     [super updateProps:props oldProps:oldProps];
 }
 

--- a/ios/Shared/ActionSheetView.swift
+++ b/ios/Shared/ActionSheetView.swift
@@ -33,10 +33,10 @@ public class ActionSheetView: UIView {
         }
     }
 
-    @objc var shouldOpenOnLongPress: Bool = false
+    @objc public var shouldOpenOnLongPress: Bool = false
 
     private var _themeVariant: String?
-    @objc var themeVariant: NSString? {
+    @objc public var themeVariant: NSString? {
         didSet { self._themeVariant = themeVariant as? String }
     }
 

--- a/ios/Shared/MenuViewImplementation.swift
+++ b/ios/Shared/MenuViewImplementation.swift
@@ -36,21 +36,21 @@ public class MenuViewImplementation: UIButton {
         }
     }
 
-    @objc var shouldOpenOnLongPress: Bool = false {
+    @objc public var shouldOpenOnLongPress: Bool = false {
         didSet {
             self.setup()
         }
     }
 
     private var _themeVariant: String?
-    @objc var themeVariant: NSString? {
+    @objc public var themeVariant: NSString? {
         didSet {
             self._themeVariant = themeVariant as? String
             self.setup()
         }
     }
 
-    @objc var hitSlop: UIEdgeInsets = .zero
+    @objc public var hitSlop: UIEdgeInsets = .zero
 
     override init(frame: CGRect) {
       super.init(frame: frame)

--- a/src/NativeModuleSpecs/UIMenuNativeComponent.ts
+++ b/src/NativeModuleSpecs/UIMenuNativeComponent.ts
@@ -48,6 +48,14 @@ export interface NativeProps extends ViewProps {
 	actions: Array<MenuAction>;
 	actionsHash: string; // just a workaround to make sure we don't have to manually compare MenuActions manually in C++ (since it's a struct and that's a pain)
 	title?: string;
+	themeVariant?: string;
+	shouldOpenOnLongPress?: boolean;
+	hitSlop: {
+		top: Int32;
+		bottom: Int32;
+		left: Int32;
+		right: Int32;
+	}	
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
# Overview
When using the new Architecture in iOS some of the props like `themeVariant`, `shouldOpenOnLongPress` and `hitSlop` are not handled correctly.

| Before      | After      |
| ------------- | ------------- |
|<img width="1512" alt="Screenshot 2024-12-01 at 14 05 20" src="https://github.com/user-attachments/assets/897595f0-bc41-4757-90a2-860f8b59a0a2">| <img width="1512" alt="Screenshot 2024-12-01 at 14 07 49" src="https://github.com/user-attachments/assets/4f102fac-d6f7-4387-ab2f-ebf830bd340d">|

# Test Plan
- validated that all props are passed correctly when using the new architecture.