### PR TITLE
feat: updated minSdkVersion to sdk version 24, inline with react-nati…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -89,7 +89,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault("compileSdkVersion")
 
   defaultConfig {
-    minSdkVersion 23
+    minSdkVersion 24
     targetSdkVersion getExtOrIntegerDefault("targetSdkVersion")
     buildConfigField "boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString()
     versionCode 1

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,5 +1,5 @@
 Menu_kotlinVersion=1.7.0
-Menu_minSdkVersion=23
+Menu_minSdkVersion=24
 Menu_targetSdkVersion=31
 Menu_compileSdkVersion=31
 Menu_ndkversion=21.4.7075529


### PR DESCRIPTION
# Overview

This PR bumps the `minSdkVersion` to `24`, following the bump made by the react native team in `react-native@0.76` ([see release notes](https://reactnative.dev/blog/2024/10/23/release-0.76-new-architecture#updates-to-minimum-ios-and-android-sdk-requirements). 
