### PR TITLE
fix(android): package was failing to compile on RN 0.77

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -53,7 +53,7 @@ class MenuView(private val mContext: ReactContext) : ReactViewGroup(mContext) {
     updateTouchDelegate()
   }
 
-  override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+  override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
     return true
   }
 


### PR DESCRIPTION
# Overview
When trying to compile our app with the new RN 0.77 we ran into the following error:
> Task :react-native-menu_menu:compileDebugKotlin FAILED
e: file:///.../@react-native-menu/menu/android/src/main/java/com/reactnativemenu/MenuView.kt:60:3 'onTouchEvent' overrides nothing. e: file:///.../@react-native-menu/menu/android/src/main/java/com/reactnativemenu/MenuView.kt:61:35 Argument type mismatch: actual type is 'android.view.MotionEvent?', but 'android.view.MotionEvent' was expected.


# Test Plan
Compiling on RN 0.77 should work