### PR TITLE
fix: fix ios crash by declaring component provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,12 @@
   "codegenConfig": {
     "name": "RNMenuViewSpec",
     "type": "components",
-    "jsSrcsDir": "src"
+    "jsSrcsDir": "src",
+    "ios": {
+      "componentProvider": {
+        "MenuView": "MenuView"
+      }
+    }
   },
   "packageManager": "yarn@4.1.1"
 }


### PR DESCRIPTION
# Overview

<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->
Newer react native versions require the `componentProvider` in codegen, so this pr adds it to resolve the crash

closes #1068

# Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Tested it with a new react native project 0.80.1
