### PR TITLE
Android: Fix not clickable via TalkBack

### DIFF
--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -52,12 +52,32 @@ class MenuView(private val mContext: ReactContext) : ReactViewGroup(mContext) {
     prepareMenu()
   }
 
+  override fun addView(child: View?, index: Int, params: ViewGroup.LayoutParams?) {
+    super.addView(child, index, params)
+    // Make child views trigger menu when clicked via TalkBack
+    child?.let {
+      it.isClickable = true
+      it.isFocusable = true
+      it.setOnClickListener {
+        performClick()
+      }
+    }
+  }
+
   override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
     return true
   }
 
   override fun onTouchEvent(ev: MotionEvent): Boolean {
     mGestureDetector.onTouchEvent(ev)
+    return true
+  }
+
+  override fun performClick(): Boolean {
+    super.performClick()
+    if (!mIsOnLongPress) {
+      prepareMenu()
+    }
     return true
   }
 


### PR DESCRIPTION
# Overview

Fixes #1189 by forwarding the child's click event to the parent menu.

The issue: The menu trigger isn't clickable via TalkBack (screen reader) on Android. You can select the menu button, but clicking it does nothing. It works fine without a screen reader, and on iOS with or without VoiceOver.

# Test Plan

```jsx
<MenuView
  actions={[{
    id: 'share',
    title: 'Share Action',
  }]}
>
  <Pressable>
    <Text>Open Menu</Text>
  </Pressable>
</MenuView>
```

Without the fix:
- Tapping it works
- Turn on TalkBack on Android, and observe that you can select the item, but clicking it does nothing

With the fix:
- Tapping it works
- Turn on TalkBack on Android, and observe that clicking it now works as expected