### PR TITLE
Update README to remove iOS installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ via yarn:
 yarn add @react-native-menu/menu
 ```
 
-### Installing on iOS with React Native 0.63 and above
-
-There is an issue(https://github.com/facebook/react-native/issues/29246) causing projects with this module to fail on build on React Native 0.63 and above.
-This issue may be fixed in future versions of react native.
-As a work around, look for lines in `[YourPrject].xcodeproj` under `LIBRARY_SEARCH_PATHS` with `"\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\"",` and change `swift-5.0` to `swift-5.3`.
-
 ## Linking
 
 The package is [automatically linked](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md) when building the app. All you need to do is:


### PR DESCRIPTION
# Overview
Removed outdated iOS installation instructions for React Native 0.63. I installed on React Natigve 0.81.x and it worked fine.


# Test Plan
No code change.