### PR TITLE
fix: preserve default menu icon colors on iOS new arch

### DIFF
--- a/ios/NewArch/MenuView.mm
+++ b/ios/NewArch/MenuView.mm
@@ -105,34 +105,39 @@ using namespace facebook::react;
         NSMutableArray<NSDictionary *> *subactionsArray = [NSMutableArray arrayWithCapacity:actions.size()];
         if (action.subactions.size() > 0) {
             for (const MenuViewActionsSubactionsStruct &subaction : action.subactions) {
-                NSDictionary *subactionDict = @{
+                NSMutableDictionary *subactionDict = [@{
                     @"id": [NSString stringWithUTF8String:subaction.id.c_str()],
                     @"title": [NSString stringWithUTF8String:subaction.title.c_str()],
-                    @"titleColor": @(subaction.titleColor),
                     @"subtitle": [NSString stringWithUTF8String:subaction.subtitle.c_str()],
                     @"state": [NSString stringWithUTF8String:subaction.state.c_str()],
                     @"image": [NSString stringWithUTF8String:subaction.image.c_str()],
-                    @"imageColor": @(subaction.imageColor),
                     @"displayInline": @(subaction.displayInline),
                     @"attributes": @{
                         @"destructive": @(subaction.attributes.destructive),
                         @"disabled": @(subaction.attributes.disabled),
                         @"hidden": @(subaction.attributes.hidden),
                     },
-                };
+                } mutableCopy];
+
+                if (subaction.titleColor != 0) {
+                    subactionDict[@"titleColor"] = @(subaction.titleColor);
+                }
+
+                if (subaction.imageColor != 0) {
+                    subactionDict[@"imageColor"] = @(subaction.imageColor);
+                }
+
                 [subactionsArray addObject:subactionDict];
             }
         }
 
         // then convert the full actions object
-        NSDictionary *actionDict = @{
+        NSMutableDictionary *actionDict = [@{
             @"id": [NSString stringWithUTF8String:action.id.c_str()],
             @"title": [NSString stringWithUTF8String:action.title.c_str()],
-            @"titleColor": @(action.titleColor),
             @"subtitle": [NSString stringWithUTF8String:action.subtitle.c_str()],
             @"state": [NSString stringWithUTF8String:action.state.c_str()],
             @"image": [NSString stringWithUTF8String:action.image.c_str()],
-            @"imageColor": @(action.imageColor),
             @"displayInline": @(action.displayInline),
             @"attributes": @{
                 @"destructive": @(action.attributes.destructive),
@@ -140,7 +145,15 @@ using namespace facebook::react;
                 @"hidden": @(action.attributes.hidden),
             },
             @"subactions": subactionsArray,
-        };
+        } mutableCopy];
+
+        if (action.titleColor != 0) {
+            actionDict[@"titleColor"] = @(action.titleColor);
+        }
+
+        if (action.imageColor != 0) {
+            actionDict[@"imageColor"] = @(action.imageColor);
+        }
 
         [actionsArray addObject:actionDict];
     }


### PR DESCRIPTION
## Summary
- stop forwarding `imageColor` and `titleColor` from the New Architecture bridge when they were not explicitly set in JS
- keep the existing behavior for explicitly provided colors

## Root cause
In the Fabric/New Architecture path, codegen turns optional `imageColor` and `titleColor` fields into plain integer props with a default value of `0`. `MenuView.mm` always forwarded those values into the Objective-C action dictionaries, so iOS treated missing `imageColor` as a real color and tinted SF Symbols to an invisible color.

This shows up as menu titles rendering correctly while icons disappear entirely on iOS New Architecture, even when the JS action config follows the documented API.

## Validation
- reproduced in an Expo 55 / React Native 0.83 app using `@react-native-menu/menu` 2.0.0
- verified that icons render again after omitting unset color props from the New Arch bridge
- change is scoped to `ios/NewArch/MenuView.mm` only