### PR TITLE
fix: Android build on Expo SDK 55 / RN 0.83 / Kotlin 2.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,10 @@ buildscript {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  if (rootProject.hasProperty("newArchEnabled")) {
+    return rootProject.getProperty("newArchEnabled") == "true"
+  }
+  return true
 }
 
 apply plugin: "com.android.library"

--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -25,8 +25,7 @@ class MenuView(private val mContext: ReactContext) : ReactViewGroup(mContext) {
   private var mGestureDetector: GestureDetector
   private var mHitSlopRect: Rect? = null
     set(value) {
-      super.hitSlopRect = value
-      mHitSlopRect = value
+      field = value
       updateTouchDelegate()
     }
 


### PR DESCRIPTION
# Overview

`@react-native-menu/menu@2.0.0` is completely broken on Android for anyone using **Expo SDK 55** (React Native 0.83, Kotlin 2.1.20). Two bugs combine to make the library unusable:

### Bug 1: `isNewArchitectureEnabled()` returns `false` on RN 0.83+

Expo SDK 55 / RN 0.83 removed the `newArchEnabled` Gradle property because New Architecture is the only option. The current implementation defaults to `false` when the property is absent, which means:

- `com.facebook.react` plugin is never applied
- `src/oldarch` sources are used instead of `src/newarch`
- Codegen is skipped entirely
- Runtime error: **"View config not found for component MenuView"**

**Fix:** Default to `true` when the property is absent — New Arch is the default for RN 0.76+ and the *only* option on 0.83+.

### Bug 2: Kotlin 2.x (K2 compiler) breaks `MenuView.kt` setter

PR #1156 switched from `setHitSlopRect()` method calls to property syntax. The K2 compiler (used by Kotlin 2.1.20 in RN 0.83) rejects `super.hitSlopRect = value` because `hitSlopRect` is declared as `val` in the `ReactHitSlopView` interface. Additionally, `mHitSlopRect = value` inside its own setter is infinite recursion (should use `field`).

This was originally fixed in v1.0.0 (PR #746) then reintroduced in v2.0.0 by #1156.

**Fix:** Use the `field` keyword to assign directly to the backing field.

Closes #1167
Fixes #1058
Related: #1179, #1186, #1187

# Test Plan

- [ ] Build an Expo SDK 55 app with `@react-native-menu/menu` on Android — should compile without errors
- [ ] Verify `MenuView` renders and opens the popup menu on tap
- [ ] Verify hit slop works correctly without stack overflow
- [ ] Verify existing Old Architecture builds still work (property falls back to `"true"` check)