### PR TITLE
fix: android build on Expo SDK 55+56 / RN 0.83 / Kotlin 2.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,7 +15,10 @@ buildscript {
 }
 
 def isNewArchitectureEnabled() {
-  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
+  if (rootProject.hasProperty("newArchEnabled")) {
+    return rootProject.getProperty("newArchEnabled") == "true"
+  }
+  return true
 }
 
 apply plugin: "com.android.library"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,10 +15,10 @@ buildscript {
 }
 
 def isNewArchitectureEnabled() {
-  if (rootProject.hasProperty("newArchEnabled")) {
-    return rootProject.getProperty("newArchEnabled") == "true"
+  if (getReactNativeMinorVersion() >= 82) {
+    return true
   }
-  return true
+  return rootProject.hasProperty("newArchEnabled") && rootProject.getProperty("newArchEnabled") == "true"
 }
 
 apply plugin: "com.android.library"

--- a/android/src/main/java/com/reactnativemenu/MenuView.kt
+++ b/android/src/main/java/com/reactnativemenu/MenuView.kt
@@ -25,8 +25,7 @@ class MenuView(private val mContext: ReactContext) : ReactViewGroup(mContext) {
   private var mGestureDetector: GestureDetector
   private var mHitSlopRect: Rect? = null
     set(value) {
-      super.hitSlopRect = value
-      mHitSlopRect = value
+      field = value
       updateTouchDelegate()
     }
 


### PR DESCRIPTION
# Overview

v2.0.0 doesn't build on Android with Expo SDK 55 (RN 0.83, Kotlin 2.1.20). Two issues:

**`isNewArchitectureEnabled()` returns false on RN 0.83+** — RN 0.83 removed the `newArchEnabled` gradle property since new arch is now the only option. Without it the function defaults to false, the `com.facebook.react` plugin never gets applied, oldarch sources are used, and codegen is skipped. Result: "View config not found for component MenuView" at runtime. This PR defaults to true when the property is absent.

**`MenuView.kt` setter breaks under K2** — #1156 switched to property syntax for `hitSlopRect`, but K2 rejects `super.hitSlopRect = value` because it's `val` in the `ReactHitSlopView` interface. The self-assignment `mHitSlopRect = value` inside its own setter is also infinite recursion. Same bug that was fixed in v1.0.0 via #746. This PR uses the `field` keyword instead.

Closes #1167, Fixes #1058
Related: #1179, #1186, #1187

# Test Plan

- Build an Expo SDK 55 project with `@react-native-menu/menu` on Android
- Verify MenuView renders and popup opens on tap
- Verify hit slop works without stack overflow
- Verify old arch builds still work (property present and set to "true"/"false")