### PR TITLE
fix: include Android anchor prop in codegen spec

### DIFF
--- a/src/NativeModuleSpecs/UIMenuNativeComponent.ts
+++ b/src/NativeModuleSpecs/UIMenuNativeComponent.ts
@@ -52,6 +52,7 @@ export interface NativeProps extends ViewProps {
 	actionsHash: string; // just a workaround to make sure we don't have to manually compare MenuActions manually in C++ (since it's a struct and that's a pain)
 	title?: string;
 	themeVariant?: string;
+	isAnchoredToRight?: boolean;
 	shouldOpenOnLongPress?: boolean;
 	hitSlop: {
 		top: Int32;


### PR DESCRIPTION
## Summary

- Add `isAnchoredToRight` to the native component codegen spec.
- This lets React Native new architecture pass the documented Android prop through to the existing native manager implementation.
