### PR TITLE
ci: publish to npm automatically from CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+# Publishes to npm automatically once `Build` has passed on master.
+#
+# The version and changelog come from release-it + @release-it/conventional-changelog
+# (see the "release-it" block in package.json), so they are derived from the
+# conventional commit messages since the previous tag.
+#
+# Requires an `NPM_TOKEN` repository secret holding an npm access token with
+# publish rights on @react-native-menu/menu.
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+    branches:
+      - master
+  # Manual escape hatch, e.g. to retry a release that failed partway through.
+  # Note this path does not check Build, so only run it on a commit you know is green.
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    # Never react to the `chore: release` commit release-it pushes itself,
+    # and never publish off a red Build.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       !startsWith(github.event.workflow_run.head_commit.message, 'chore: release'))
+    permissions:
+      # release-it pushes the release commit and tag, and creates the GitHub release.
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: master
+          # Full history and tags, so conventional-changelog can see the commits
+          # since the previous release.
+          fetch-depth: 0
+
+      - name: Decide whether to release
+        id: guard
+        run: |
+          set -euo pipefail
+
+          # `Build` validated a specific commit. If master has moved on since then,
+          # publishing now would ship code CI never checked.
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            expected='${{ github.event.workflow_run.head_sha }}'
+            actual="$(git rev-parse HEAD)"
+            if [ "$expected" != "$actual" ]; then
+              echo "master moved past the commit Build validated ($expected -> $actual)."
+              echo "Skipping; the next green Build will pick this up."
+              echo "release=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -n "$last_tag" ]; then
+            range="$last_tag..HEAD"
+          else
+            range="HEAD"
+          fi
+
+          # Only feat/fix/perf and breaking changes produce a version bump under the
+          # angular preset. Without one, release-it has nothing to do.
+          releasable="$(git log "$range" --format='%s%n%b' \
+            | grep -cE '^(feat|fix|perf)(\([^)]*\))?!?: |^BREAKING[ -]CHANGE:' || true)"
+
+          echo "Releasable commits since ${last_tag:-the start of history}: $releasable"
+          if [ "$releasable" -eq 0 ]; then
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/setup-node@v4
+        if: steps.guard.outputs.release == 'true'
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        if: steps.guard.outputs.release == 'true'
+        run: yarn install --immutable
+
+      - name: Configure git identity
+        if: steps.guard.outputs.release == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+      - name: Release
+        if: steps.guard.outputs.release == 'true'
+        run: yarn release --ci
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # setup-node writes an .npmrc that reads NODE_AUTH_TOKEN.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,27 @@ When you're sending a pull request:
 - For pull requests that change the API or implementation, discuss with maintainers first by opening an issue.
 - For version-dependent changes, follow the versioning structure for `MenuViewManager` outlined in the **Versioning in `MenuViewManager`** section. Ensure all version-specific files are included in `reactNativeVersionPatch` and referenced in `build.gradle`.
 
+### Releasing
+
+Releases are automated. Merging to `master` is all that is needed — no one runs `yarn release` locally.
+
+`.github/workflows/release.yml` waits for the `Build` workflow to finish on `master` and then, if it passed, runs `release-it` in CI. `@release-it/conventional-changelog` derives the new version and the release notes from the commit messages since the previous tag, so **the version bump is decided entirely by your commit message**:
+
+- `fix:` or `perf:` → patch
+- `feat:` → minor
+- `!` after the type, or a `BREAKING CHANGE:` footer → major
+
+A push containing only `chore:`, `docs:`, `test:`, or `refactor:` commits releases nothing, and the workflow stops before touching npm. Note that nothing currently enforces the commit format, so a `feat` mislabelled as `chore` silently ships nothing — squash-merge titles matter here.
+
+The workflow publishes to npm, pushes the `chore: release <version>` commit and the `v<version>` tag, and creates the GitHub release. It authenticates with an `NPM_TOKEN` repository secret; if publishing starts failing with an auth error, that token has most likely expired.
+
+Two things the workflow deliberately refuses to do:
+
+- It skips if `master` has moved past the commit `Build` validated, rather than publishing code CI never checked. The next green `Build` picks it up.
+- It ignores its own `chore: release` commit, so a release cannot trigger another release.
+
+`Release` can also be started manually from the Actions tab, which is useful when a release fails partway through. That path skips the `Build` gate, so only use it on a commit you know is green.
+
 ## Code of Conduct
 
 ### Our Pledge

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -11,7 +11,7 @@
 # particularly useful for configuring JVM memory settings for build performance.
 # This does not affect the JVM settings for the Gradle client VM.
 # The default is `-Xmx512m -XX:MaxMetaspaceSize=256m`.
-org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 
 # When configured, Gradle will fork up to org.gradle.workers.max JVMs to execute
 # projects in parallel. To learn more about parallel task execution, see the


### PR DESCRIPTION
# Overview

Implements #1223. Releases move from a manual local operation to a CI workflow.

Today a release means a maintainer running `yarn release` with npm credentials on hand. Every published release is authored by one person, and `master` currently carries four releasable commits since `v2.0.0` that have never reached npm — `feat(ios): preferredElementSize` (#1202) plus three `fix:` commits.

The release tooling itself was already configured; only the automation was missing. This PR does not change how versions or changelogs are produced.

## `.github/workflows/release.yml`

Triggers on the `Build` workflow completing on `master` and runs the existing `release-it` configuration if Build passed. Using `workflow_run` means the gate is exact — lint, tsc, android, and both iOS builds must be green before anything is published — and it builds on the push trigger fixed in #1224.

Version and release notes still come from `@release-it/conventional-changelog`, so the output matches the current manual release. The bump is decided entirely by commit messages: `fix:`/`perf:` → patch, `feat:` → minor, `!` or a `BREAKING CHANGE:` footer → major.

Two guards:

- **Unvalidated commits are never published.** If `master` has moved past the commit Build validated, the run skips instead of shipping code CI never checked. The next green Build picks it up.
- **A release cannot trigger another release.** The `chore: release <version>` commit that release-it pushes is ignored.

A push whose commits are all `chore`/`docs`/`test`/`refactor` stops before touching npm, since the angular preset would produce no bump.

Authentication uses an `NPM_TOKEN` repository secret, read through the `.npmrc` that `actions/setup-node` writes. `GITHUB_TOKEN` with `contents: write` covers the release commit, tag, and GitHub release.

`Release` can also be dispatched manually for a release that failed partway through. That path skips the Build gate by design and is documented as such.

## Gradle heap bump

Separate commit, and a prerequisite rather than an unrelated drive-by. The `android` job fails intermittently — roughly half of recent runs — during dependency resolution:

```
Failed to transform react-android-0.81.1-debug.aar
  > Execution failed for JetifyTransform: .../react-android-0.81.1-debug.aar
     > Java heap space
```

It failed on #1222's first attempt and on the `master` push run after #1224 merged, and passed on #1222's re-run and on #1224. Since publishing is gated on a green Build, a job that fails half the time blocks releases half the time. `-Xmx2g` is no longer enough for the Jetifier transform; ubuntu runners have ample memory.

## Before the first release

An npm access token with publish rights on `@react-native-menu/menu` must be added as an `NPM_TOKEN` repository secret. Without it the workflow runs and fails at the publish step.

Two things worth checking:

- **Branch protection.** release-it pushes the release commit and tag directly to `master`. If `master` requires pull requests or status checks for pushes, `GITHUB_TOKEN` will be rejected and the release will fail *after* publishing to npm, leaving npm and git out of sync.
- **Commit messages are now load-bearing.** With release-on-merge, a `feat` mislabelled as `chore` silently ships nothing. `CONTRIBUTING.md` states that pre-commit hooks verify the format, but no husky, lefthook, or commitlint configuration exists in the repo — so squash-merge titles are what actually decide the version. This is documented rather than enforced; wiring up commitlint would be a separate change.

# Test Plan

A `workflow_run` trigger only fires from the workflow file on the default branch, so this workflow cannot execute before merge. The first merge to `master` is the real test. What was verified instead:

- **The release guard was run against real history, not eyeballed.** On the current `master` it resolves `git describe --tags --abbrev=0` to `v2.0.0`, walks `v2.0.0..HEAD`, and finds exactly 4 releasable commits — the 1 `feat` and 3 `fix` listed above — which is a minor bump. Re-running it after a release would find 0 and skip.
- The guard's regex requires colon-space, matching `conventional-changelog`'s own header parser, so the guard and release-it agree on what counts as releasable. (Note this means a historical subject like `fix:lint error` would be skipped by both, consistently.)
- `release.yml` was parsed as YAML to confirm it is well formed.
- The Jetifier OOM was read from the failing job logs of run `31983633654` (the `master` push run) and cross-checked against the same failure on #1222, confirming it happens in `:app:checkDebugAarMetadata` during dependency transform, before any project code compiles.
- `yarn lint` could not be run — dependencies are not installed in this environment. Biome 1.9.4 covers JS/TS/JSON, and this diff is YAML, Markdown, and a `.properties` file, so it is outside Biome's scope regardless. The `lint` job on this PR confirms it.

The `android` job on this PR is the first check of the heap bump; if it passes here and on subsequent runs, the OOM is addressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GWYKHSVSNoLM8Hquum8CuD)_